### PR TITLE
+4 active skills  and skill weight system

### DIFF
--- a/Content.Server/_CE/Skills/Blessing/CEBlessingSystem.cs
+++ b/Content.Server/_CE/Skills/Blessing/CEBlessingSystem.cs
@@ -234,7 +234,18 @@ public sealed partial class CEBlessingSystem : CESharedBlessingSystem
             return null;
         }
 
-        return _random.Pick(candidates);
+        // Weighted random selection: skills with higher Weight appear more often
+        var totalWeight = candidates.Sum(c => c.Weight);
+        var roll = _random.NextFloat() * totalWeight;
+        var accumulated = 0f;
+        foreach (var candidate in candidates)
+        {
+            accumulated += candidate.Weight;
+            if (roll < accumulated)
+                return candidate.ID;
+        }
+
+        return candidates[^1].ID;
     }
 
     private List<CESkillPrototype> GetSkillCandidates(

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -4,6 +4,7 @@ using Content.Shared._CE.Fire;
 using Content.Shared._CE.Frost;
 using Content.Shared._CE.Health;
 using Content.Shared._CE.Mana.Core;
+using Content.Shared._CE.MeleeWeapon;
 using Content.Shared._CE.Stamina;
 using Content.Shared._CE.TempShield;
 using Content.Shared.Body.Events;
@@ -37,9 +38,9 @@ public sealed partial class StatusEffectsSystem
         SubscribeLocalEvent<StatusEffectContainerComponent, CEGetManaRestoreAmountEvent>(RelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, CEDivineShieldBrokenEvent>(RelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, CECalculateTempShieldStacksEvent>(RelayStatusEffectEvent);
+        SubscribeLocalEvent<StatusEffectContainerComponent, CEAfterAttackEvent>(RelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, CEFreezeEntityAttemptEvent>(RefRelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, CEIgniteEntityAttemptEvent>(RefRelayStatusEffectEvent);
-
         //CrystallEdge zone end
 
         SubscribeLocalEvent<StatusEffectContainerComponent, LocalPlayerAttachedEvent>(RelayStatusEffectEvent);

--- a/Content.Shared/_CE/MeleeWeapon/CESharedWeaponSystem.cs
+++ b/Content.Shared/_CE/MeleeWeapon/CESharedWeaponSystem.cs
@@ -42,7 +42,7 @@ public abstract partial class CESharedWeaponSystem : EntitySystem
         SubscribeAllEvent<CEStopWeaponUseEvent>(OnClientStopRequest);
         SubscribeAllEvent<CEWeaponArcHitEvent>(OnArcHitEvent);
 
-        SubscribeLocalEvent<CEWieldedWeaponComponent, CEGetWeaponEvent>(OnGetWeapon);
+        SubscribeLocalEvent<CEWieldedWeaponComponent, CEGetWeaponAnimationsEvent>(OnGetWeapon);
     }
 
     private void OnArcHitEvent(CEWeaponArcHitEvent ev, EntitySessionEventArgs args)
@@ -78,7 +78,7 @@ public abstract partial class CESharedWeaponSystem : EntitySystem
     {
     }
 
-    private void OnGetWeapon(Entity<CEWieldedWeaponComponent> ent, ref CEGetWeaponEvent args)
+    private void OnGetWeapon(Entity<CEWieldedWeaponComponent> ent, ref CEGetWeaponAnimationsEvent args)
     {
         if (args.Handled)
             return;
@@ -154,7 +154,7 @@ public abstract partial class CESharedWeaponSystem : EntitySystem
         //Get animations
         List<CEAnimationEntry> animations = new();
 
-        var animEv = new CEGetWeaponEvent(used, useType);
+        var animEv = new CEGetWeaponAnimationsEvent(used, useType);
         RaiseLocalEvent(used, animEv);
 
         if (animEv.Handled && animEv.Animations.Count != 0)
@@ -201,7 +201,7 @@ public abstract partial class CESharedWeaponSystem : EntitySystem
     {
         used = null;
 
-        var ev = new CEGetAnimationItemForUseEvent();
+        var ev = new CEGetWeaponEvent();
         RaiseLocalEvent(entity, ev);
         if (ev.Handled && ev.Used != null)
         {
@@ -242,19 +242,10 @@ public abstract partial class CESharedWeaponSystem : EntitySystem
 
     /// <summary>
     /// Returns whether the user is allowed to attack.
-    /// Checks container state and raises <see cref="CEAttackAttemptEvent"/>.
     /// </summary>
     public bool CanAttack(EntityUid user, EntityUid? target = null, Entity<CEWeaponComponent>? weapon = null)
     {
         return Blocker.CanAttack(user, target);
-
-        //if (!Blocker.CanAttack(user, target))
-        //    return false;
-//
-        //var ev = new CEAttackAttemptEvent(user, target, weapon);
-        //RaiseLocalEvent(user, ev);
-//
-        //return !ev.Cancelled;
     }
 
     /// <summary>

--- a/Content.Shared/_CE/MeleeWeapon/Events.cs
+++ b/Content.Shared/_CE/MeleeWeapon/Events.cs
@@ -6,11 +6,20 @@ namespace Content.Shared._CE.MeleeWeapon;
 /// <summary>
 /// Is called on the object being used to determine what animations it provides
 /// </summary>
-public sealed class CEGetWeaponEvent(Entity<CEWeaponComponent> used, CEUseType useType) : HandledEntityEventArgs
+public sealed class CEGetWeaponAnimationsEvent(Entity<CEWeaponComponent> used, CEUseType useType) : HandledEntityEventArgs
 {
     public Entity<CEWeaponComponent> Used = used;
     public CEUseType UseType = useType;
     public List<CEAnimationEntry> Animations = new();
+}
+
+/// <summary>
+/// Event raised on entity in GetWeapon function to allow systems to manually
+/// specify what the weapon should be.
+/// </summary>
+public sealed class CEGetWeaponEvent : HandledEntityEventArgs
+{
+    public Entity<CEWeaponComponent>? Used;
 }
 
 /// <summary>
@@ -59,15 +68,6 @@ public sealed class CEWeaponArcHitEvent(
     /// Used by the server to replay nested effects on validated targets.
     /// </summary>
     public readonly string? EffectSlot = effectSlot;
-}
-
-/// <summary>
-/// Event raised on entity in GetWeapon function to allow systems to manually
-/// specify what the weapon should be.
-/// </summary>
-public sealed class CEGetAnimationItemForUseEvent : HandledEntityEventArgs
-{
-    public Entity<CEWeaponComponent>? Used;
 }
 
 /// <summary>

--- a/Content.Shared/_CE/Skill/Core/Prototypes/CESkillPrototype.cs
+++ b/Content.Shared/_CE/Skill/Core/Prototypes/CESkillPrototype.cs
@@ -70,6 +70,14 @@ public sealed partial class CESkillPrototype : IPrototype, IInheritingPrototype
     /// </summary>
     [DataField]
     public bool Unique = true;
+
+    /// <summary>
+    /// Relative weight of this skill when it is randomly selected for a player.
+    /// Higher values make the skill appear more frequently. Defaults to 1.
+    /// </summary>
+    [DataField]
+    [AlwaysPushInheritance]
+    public float Weight = 1f;
 }
 
 [ImplicitDataDefinitionForInheritors]

--- a/Content.Shared/_CE/Skill/Skills/Cruelty/CEEffectOnAttackStatusEffectComponent.cs
+++ b/Content.Shared/_CE/Skill/Skills/Cruelty/CEEffectOnAttackStatusEffectComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared._CE.EntityEffect;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CE.Skill.Skills.Cruelty;
+
+/// <summary>
+/// Apply CEEntityEffects on melee attack targets, then remove stacks of this status effect
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CEEffectOnAttackStatusEffectComponent : Component
+{
+    [DataField]
+    public List<CEEntityEffect> Effects = new();
+
+    [DataField]
+    public int StackCost = 0;
+
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    [DataField]
+    public EntityWhitelist? Blacklist;
+}

--- a/Content.Shared/_CE/Skill/Skills/Cruelty/CEEffectOnAttackStatusEffectSystem.cs
+++ b/Content.Shared/_CE/Skill/Skills/Cruelty/CEEffectOnAttackStatusEffectSystem.cs
@@ -1,0 +1,53 @@
+using Content.Shared._CE.DivineShield;
+using Content.Shared._CE.EntityEffect;
+using Content.Shared._CE.MeleeWeapon;
+using Content.Shared._CE.Skill.Skills.DivineShieldBreakEffect;
+using Content.Shared._CE.StatusEffectStacks;
+using Content.Shared.StatusEffectNew;
+using Content.Shared.StatusEffectNew.Components;
+using Content.Shared.Whitelist;
+
+namespace Content.Shared._CE.Skill.Skills.Cruelty;
+
+public sealed class CEEffectOnAttackStatusEffectSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly CEStatusEffectStackSystem _stack = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CEEffectOnAttackStatusEffectComponent, StatusEffectRelayedEvent<CEAfterAttackEvent>>(OnAfterAttack);
+    }
+
+    private void OnAfterAttack(Entity<CEEffectOnAttackStatusEffectComponent> ent, ref StatusEffectRelayedEvent<CEAfterAttackEvent> args)
+    {
+        if (!TryComp<StatusEffectComponent>(ent, out var status) || status.AppliedTo is null)
+            return;
+
+        if (args.Args.Targets.Count <= 0)
+            return;
+
+        foreach (var target in args.Args.Targets)
+        {
+            if (!_whitelist.CheckBoth(target, ent.Comp.Blacklist, ent.Comp.Whitelist))
+                continue;
+
+            var effectArgs = new CEEntityEffectArgs(
+                EntityManager,
+                status.AppliedTo.Value,
+                args.Args.Weapon,
+                Angle.Zero,
+                1f,
+                target,
+                Transform(target).Coordinates);
+
+            foreach (var effect in ent.Comp.Effects)
+            {
+                effect.Effect(effectArgs);
+            }
+        }
+
+        _stack.TryRemoveStack(ent.Owner, ent.Comp.StackCost);
+    }
+}

--- a/Content.Shared/_CE/Skill/Skills/DivineShieldBreakEffect/CEDivineShieldBreakEffectComponent.cs
+++ b/Content.Shared/_CE/Skill/Skills/DivineShieldBreakEffect/CEDivineShieldBreakEffectComponent.cs
@@ -3,7 +3,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._CE.Skill.Skills.DivineShieldBreakEffect;
 
-//Spawn EntityEffects when divine shield broken
+/// <summary>
+/// Applies CEEntityEffects when Divine shield breaks
+/// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class CEDivineShieldBreakEffectComponent : Component
 {

--- a/Content.Shared/_CE/Skill/Skills/DivineShieldBreakEffect/CEDivineShieldBreakEffectSystem.cs
+++ b/Content.Shared/_CE/Skill/Skills/DivineShieldBreakEffect/CEDivineShieldBreakEffectSystem.cs
@@ -23,7 +23,7 @@ public sealed class CEDivineShieldBreakEffectSystem : EntitySystem
             args.Args.Applier ?? args.Args.ShieldHolder,
             null,
             Angle.Zero,
-            0f,
+            1f,
             args.Args.ShieldHolder,
             Transform(args.Args.ShieldHolder).Coordinates);
 

--- a/Content.Shared/_CE/Water/CESharedWaterSystem.cs
+++ b/Content.Shared/_CE/Water/CESharedWaterSystem.cs
@@ -249,7 +249,7 @@ public abstract class CESharedWaterSystem : EntitySystem
                 var normalizedDistance = distance / radius;
                 var stacks = (int)MathF.Ceiling((1f - MathF.Pow(normalizedDistance, falloffFactor)) * maxStacks);
 
-                WetTile((gridUid, grid), tileCoords, Math.Max(1, stacks), stacks, null, playSound: false);
+                WetTile((gridUid, grid), tileCoords, Math.Max(1, stacks), stacks, playSound: false);
             }
         }
 
@@ -261,7 +261,7 @@ public abstract class CESharedWaterSystem : EntitySystem
     /// <summary>
     /// Checks if an entity is standing on a tile that contains a water entity.
     /// </summary>
-    protected bool IsOnWater(Entity<TransformComponent> ent)
+    private bool IsOnWater(Entity<TransformComponent> ent)
     {
         var xform = ent.Comp;
         if (xform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))

--- a/Resources/Prototypes/_CE/Entities/Objects/Weapons/sacrificial_dagger.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Weapons/sacrificial_dagger.yml
@@ -23,7 +23,7 @@
           ignoreArmor: true
           damage:
             types:
-              Physical: 5
+              Physical: 10
         - !type:Damage
           effectTarget: Used
           damage:
@@ -39,13 +39,13 @@
         effectTarget: Used
         damage:
           types:
-            Physical: 5
+            Physical: 1
       - !type:Damage
         effectTarget: User
         ignoreArmor: true
         damage:
           types:
-            Physical: 1
+            Physical: 10
       - !type:RestoreMana
         effectTarget: User
         amount: 3

--- a/Resources/Prototypes/_CE/Skills/Generic/Actives/self_treatment.yml
+++ b/Resources/Prototypes/_CE/Skills/Generic/Actives/self_treatment.yml
@@ -1,6 +1,7 @@
 - type: skill
   parent: BaseNeutralSkill
   id: SelfTreatment
+  weight: 0.5
   effect: !type:AddAction
     action: CEActionSpellSelfTreatment
   restrictions:

--- a/Resources/Prototypes/_CE/Skills/Generic/Actives/small_barrier_cold.yml
+++ b/Resources/Prototypes/_CE/Skills/Generic/Actives/small_barrier_cold.yml
@@ -1,0 +1,41 @@
+- type: skill
+  parent: BaseNeutralSkill
+  id: SmallBarrierFrost
+  weight: 0.15 # 3 small barrier skills pretty similar to each other so we merge it probabilities (0.15 + 0.15 + 0.15 = 0.45 and that ~ 0.5 default for neutral skill)
+  icon:
+    sprite: _CE/Interface/temp_shield.rsi
+    state: frost
+  effect: !type:AddAction
+    action: CEActionSpellSmallBarrierFrost
+
+- type: entity
+  id: CEActionSpellSmallBarrierFrost
+  parent: CEActionSpellBase
+  name: Small frost barrier
+  description: Grants [color=#b2e3eb]20 temporary Frost shields[/color] that absorb damage. Shields decay over time.
+  components:
+  - type: CEActionManaCost
+    manaCost: 1 #TODO: Change to 3, when cold damage become more frequent
+  - type: Action
+    useDelay: 10
+    icon:
+      sprite: _CE/Interface/temp_shield.rsi
+      state: frost
+  - type: InstantAction
+    event: !type:CEInstantActionAnimationEvent
+      animation: SmallBarrierFrost
+
+- type: entityEffectAnimation
+  id: SmallBarrierFrost
+  movementSpeed: 0.5
+  duration: 1
+  events:
+    0:
+    - !type:PlaySound
+      sound:
+        path: /Audio/Magic/rumble.ogg
+    0.6:
+    - !type:AddTempShield
+      effectTarget: User
+      amount: 20
+      damageType: Cold

--- a/Resources/Prototypes/_CE/Skills/Generic/Actives/small_barrier_fire.yml
+++ b/Resources/Prototypes/_CE/Skills/Generic/Actives/small_barrier_fire.yml
@@ -1,0 +1,41 @@
+- type: skill
+  parent: BaseNeutralSkill
+  id: SmallBarrierFire
+  weight: 0.15 # 3 small barrier skills pretty similar to each other so we merge it probabilities (0.15 + 0.15 + 0.15 = 0.45 and that ~ 0.5 default for neutral skill)
+  icon:
+    sprite: _CE/Interface/temp_shield.rsi
+    state: fire
+  effect: !type:AddAction
+    action: CEActionSpellSmallBarrierFire
+
+- type: entity
+  id: CEActionSpellSmallBarrierFire
+  parent: CEActionSpellBase
+  name: Small fire barrier
+  description: Grants [color=#b2e3eb]20 temporary fire shields[/color] that absorb damage. Shields decay over time.
+  components:
+  - type: CEActionManaCost
+    manaCost: 3
+  - type: Action
+    useDelay: 10
+    icon:
+      sprite: _CE/Interface/temp_shield.rsi
+      state: fire
+  - type: InstantAction
+    event: !type:CEInstantActionAnimationEvent
+      animation: SmallBarrierFire
+
+- type: entityEffectAnimation
+  id: SmallBarrierFire
+  movementSpeed: 0.5
+  duration: 1
+  events:
+    0:
+    - !type:PlaySound
+      sound:
+        path: /Audio/Magic/rumble.ogg
+    0.6:
+    - !type:AddTempShield
+      effectTarget: User
+      amount: 20
+      damageType: Fire

--- a/Resources/Prototypes/_CE/Skills/Generic/Actives/small_barrier_physical.yml
+++ b/Resources/Prototypes/_CE/Skills/Generic/Actives/small_barrier_physical.yml
@@ -1,0 +1,46 @@
+- type: skill
+  parent: BaseNeutralSkill
+  id: SmallBarrierPhysical
+  weight: 0.15 # 3 small barrier skills pretty similar to each other so we merge it probabilities (0.15 + 0.15 + 0.15 = 0.45 and that ~ 0.5 default for neutral skill)
+  icon:
+    sprite: _CE/Interface/temp_shield.rsi
+    state: physical
+  effect: !type:AddAction
+    action: CEActionSpellSmallBarrierPhysical
+  restrictions:
+   - !type:JobWhitelist
+     inverted: true
+     jobs:
+     - CEKnight #This skill is useless for knight
+
+- type: entity
+  id: CEActionSpellSmallBarrierPhysical
+  parent: CEActionSpellBase
+  name: Small physical barrier
+  description: Grants [color=#b2e3eb]20 temporary Physical shields[/color] that absorb damage. Shields decay over time.
+  components:
+  - type: CEActionManaCost
+    manaCost: 3
+  - type: Action
+    useDelay: 10
+    icon:
+      sprite: _CE/Interface/temp_shield.rsi
+      state: physical
+  - type: InstantAction
+    event: !type:CEInstantActionAnimationEvent
+      animation: SmallBarrierPhysical
+
+- type: entityEffectAnimation
+  id: SmallBarrierPhysical
+  movementSpeed: 0.5
+  duration: 1
+  events:
+    0:
+    - !type:PlaySound
+      sound:
+        path: /Audio/Magic/rumble.ogg
+    0.6:
+    - !type:AddTempShield
+      effectTarget: User
+      amount: 20
+      damageType: Physical

--- a/Resources/Prototypes/_CE/Skills/Generic/Actives/sphere_of_light.yml
+++ b/Resources/Prototypes/_CE/Skills/Generic/Actives/sphere_of_light.yml
@@ -1,6 +1,7 @@
 - type: skill
   parent: BaseNeutralSkill
   id: SphereOfLight
+  weight: 0.5
   effect: !type:AddAction
     action: CEActionSpellSphereOfLight
 

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
@@ -2,7 +2,7 @@
   parent: BaseKnightSkill
   id: Cruelty
   icon:
-    sprite: _CE/Skills/Knight/cruelty.rsi
+    sprite: _CE/Skills/Knight/focus.rsi
     state: icon
   effect: !type:AddAction
     action: CEActionSpellCruelty
@@ -19,7 +19,7 @@
   - type: Action
     useDelay: 10
     icon:
-      sprite: _CE/Skills/Knight/cruelty.rsi
+      sprite: _CE/Skills/Knight/focus.rsi
       state: icon
   - type: InstantAction
     event: !type:CEInstantActionAnimationEvent

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
@@ -1,0 +1,131 @@
+- type: skill
+  parent: BaseKnightSkill
+  id: Cruelty
+  icon:
+    sprite: _CE/Skills/Knight/cruelty.rsi
+    state: icon
+  effect: !type:AddAction
+    action: CEActionSpellCruelty
+
+- type: entity
+  id: CEActionSpellCruelty
+  parent: CEActionSpellBase
+  name: Cruelty
+  description: Your next melee attack applies [color=#b2e3eb]5 Bruise[/color] stacks, increasing the physical damage taken by targets.
+  components:
+  - type: CEActionManaCost
+    manaCost: 4
+  - type: CEActionWeaponRequired
+  - type: Action
+    useDelay: 10
+    icon:
+      sprite: _CE/Skills/Knight/cruelty.rsi
+      state: icon
+  - type: InstantAction
+    event: !type:CEInstantActionAnimationEvent
+      animation: AnimationCruelty
+
+- type: entityEffectAnimation
+  id: AnimationCruelty
+  movementSpeed: 0.5
+  duration: 1
+  events:
+    0:
+    - !type:PlaySound
+      sound:
+        path: /Audio/Magic/rumble.ogg
+    - !type:ActiveHandEntityAnimation
+      offsetAnimation:
+      - time: 0
+        offset: -0, -0.3
+        easing: QuadIn
+      - time: 0.4
+        offset: -0.5, -0.2
+      - time: 0.8
+        offset: -0.5, 0.1
+        easing: QuadOut
+      rotationAnimation:
+      - time: 0
+        rotation: 90
+        easing: QuadIn
+      - time: 0.4
+        rotation: -30
+      - time: 0.8
+        rotation: -90
+        easing: QuadOut
+      colorAnimation:
+        - time: 0.9
+          color: "#ffffff"
+        - time: 1
+          color: "#ffffff01"
+    0.6:
+    - !type:UsedEntityAnimation
+      dummyEntity: CEEffectCrueltyTelegraphy
+      offsetAnimation:
+      - time: 0
+        offset: -0.6, 0.1
+    - !type:ApplyStatusEffectStack
+      effectTarget: User
+      statusEffect: CEStatusEffectCruelty
+      duration: 10
+
+- type: entity
+  id: CEEffectCrueltyTelegraphy
+  parent: CEBaseMagicImpact
+  categories: [ ForkFiltered ]
+  suffix: VFX
+  name: focus cruelty
+  save: false
+  components:
+  - type: Sprite
+    drawdepth: Effects
+    sprite: _CE/Effects/critical_charge.rsi
+    layers:
+    - state: effect
+      shader: unshaded
+  - type: PointLight
+    color: "#ff0505"
+    radius: 1.5
+  - type: TimedDespawn
+    lifetime: 1.5
+  - type: LightBehaviour
+    behaviours:
+      - !type:PulseBehaviour
+        interpolate: Linear
+        maxDuration: 1.5
+        startValue: 0
+        endValue: 5.0
+        property: Energy
+        isLooped: false
+        enabled: true
+
+- type: entity
+  id: CEStatusEffectCruelty
+  name: Cruelty
+  description: Your next melee attack applies [color=#b2e3eb]5 Bruise[/color] stacks, increasing the physical damage taken by targets.
+  components:
+  - type: Sprite
+    noRot: true
+    drawdepth: Effects
+    sprite: _CE/Effects/focus_status.rsi
+    layers:
+    - state: effect
+      shader: unshaded
+  - type: StatusEffect
+  - type: StatusEffectAlert
+    alert: CECruelty
+  - type: CEEffectOnAttackStatusEffect
+    stackCost: 1
+    effects:
+    - !type:AddDamageVulnerability
+      damageType: Physical
+      amount: 5
+  - type: PointLight
+    color: "#0e0808"
+    radius: 1.9
+
+- type: alert
+  id: CECruelty
+  icons:
+  - sprite: _CE/Skills/Knight/focus.rsi
+    state: icon

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
@@ -25,10 +25,10 @@
       state: icon
   - type: InstantAction
     event: !type:CEInstantActionAnimationEvent
-      animation: AnimationIronBulwark
+      animation: IronBulwark
 
 - type: entityEffectAnimation
-  id: AnimationIronBulwark
+  id: IronBulwark
   movementSpeed: 0.5
   duration: 1
   events:

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
@@ -13,6 +13,9 @@
   name: Iron Bulwark
   description: Grants [color=#b2e3eb]40 temporary physical shields[/color] that absorb damage. Shields decay over time.
   components:
+  - type: Sprite
+    sprite: _CE/Skills/Knight/iron_bulwark.rsi
+    state: icon
   - type: CEActionManaCost
     manaCost: 2
   - type: Action


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
- Cruelty - Активный скилл для воина. Заряжает следующую атаку ближнего боя, и она наносит дополнительно 5 стаков "Bruise" увеличивающие получаемый урон.
- 3 Small barrier - 3 нейтральных активных скилла. Дает 20 временных щитов от огня, льда или физического урона. Ледяной щит т.к. самый бесполезный стоит очень мало маны.

Добавлено поле Weight в SkillPrototype, что контролирует шанс появления скилла.
Все нейтральные скиллы поставлены на 0.5, что снижает их шанс выпадения в 2 раза. Так как их эффекты обычно слабее чем классовые способности.

3 навыка малых барьеров получили weight 0.15 так как геймплейно очень похожи и будут считаться как "один" скилл по  вероятностям.

---

- Cruelty - An active skill for the Warrior. Charges the next melee attack, causing it to inflict an additional 5 “Bruise” stacks, which increase incoming damage.
- 3 Small Barrier - 3 neutral active skills. Grants 20 temporary shields against fire, ice, or physical damage. The ice shield, being the least useful, costs very little mana.

Added a “Weight” field to SkillPrototype, which controls the skill's drop chance.
All neutral skills have been set to 0.5, which halves their drop chance. This is because their effects are generally weaker than class abilities.

The 3 Small Barrier skills have been given a weight of 0.15 since they are very similar in gameplay and will be treated as a “single” skill in terms of probability.