### PR TITLE
Fix CE health tests

### DIFF
--- a/Content.IntegrationTests/Tests/_CE/Health/CEHealthSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_CE/Health/CEHealthSystemTest.cs
@@ -29,7 +29,6 @@ public sealed class CEHealthSystemTest : GameTest
     destroyThreshold: 25
 ";
 
-    /*
     #region TakeDamage
 
     /// <summary>
@@ -52,7 +51,7 @@ public sealed class CEHealthSystemTest : GameTest
 
             damageableSystem.TakeDamage(ent, damage);
 
-            Assert.That(damageable.TotalDamage, Is.EqualTo(20));
+            Assert.That(damageable.Damage.Total, Is.EqualTo(20));
 
             entManager.DeleteEntity(ent);
         });
@@ -79,7 +78,7 @@ public sealed class CEHealthSystemTest : GameTest
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.False);
-                Assert.That(damageable.TotalDamage, Is.EqualTo(0));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(0));
             });
 
             entManager.DeleteEntity(ent);
@@ -108,7 +107,7 @@ public sealed class CEHealthSystemTest : GameTest
             damageableSystem.TakeDamage(ent, new CEDamageSpecifier(TestDamageType, 20));
             damageableSystem.Heal(ent, 500);
 
-            Assert.That(damageable.TotalDamage, Is.EqualTo(0));
+            Assert.That(damageable.Damage.Total, Is.EqualTo(0));
 
             entManager.DeleteEntity(ent);
         });
@@ -130,13 +129,13 @@ public sealed class CEHealthSystemTest : GameTest
             var damageable = entManager.GetComponent<CEDamageableComponent>(ent);
 
             damageableSystem.TakeDamage(ent, new CEDamageSpecifier(TestDamageType, 10));
-            Assert.That(damageable.TotalDamage, Is.EqualTo(10));
+            Assert.That(damageable.Damage.Total, Is.EqualTo(10));
 
             damageableSystem.Heal(ent, 0);
-            Assert.That(damageable.TotalDamage, Is.EqualTo(10));
+            Assert.That(damageable.Damage.Total, Is.EqualTo(10));
 
             damageableSystem.Heal(ent, -5);
-            Assert.That(damageable.TotalDamage, Is.EqualTo(10));
+            Assert.That(damageable.Damage.Total, Is.EqualTo(10));
 
             entManager.DeleteEntity(ent);
         });
@@ -170,7 +169,7 @@ public sealed class CEHealthSystemTest : GameTest
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.True);
-                Assert.That(damageable.TotalDamage, Is.EqualTo(30));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(30));
                 Assert.That(mobState.CurrentState, Is.EqualTo(CEMobState.Alive));
                 Assert.That(mobStateSystem.IsAlive(ent), Is.True);
             });
@@ -180,7 +179,7 @@ public sealed class CEHealthSystemTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(damageable.TotalDamage, Is.EqualTo(100));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(100));
                 Assert.That(mobState.CurrentState, Is.EqualTo(CEMobState.Critical));
                 Assert.That(mobStateSystem.IsCritical(ent), Is.True);
                 Assert.That(mobStateSystem.IsAlive(ent), Is.False);
@@ -192,7 +191,7 @@ public sealed class CEHealthSystemTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(damageable.TotalDamage, Is.EqualTo(90));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(90));
                 Assert.That(mobState.CurrentState, Is.EqualTo(CEMobState.Alive));
                 Assert.That(mobStateSystem.IsAlive(ent), Is.True);
             });
@@ -202,7 +201,7 @@ public sealed class CEHealthSystemTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(damageable.TotalDamage, Is.EqualTo(100089));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(100089));
                 Assert.That(mobState.CurrentState, Is.EqualTo(CEMobState.Critical));
                 Assert.That(mobStateSystem.IsCritical(ent), Is.True);
                 Assert.That(mobStateSystem.IsAlive(ent), Is.False);
@@ -239,7 +238,7 @@ public sealed class CEHealthSystemTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(damageable.TotalDamage, Is.EqualTo(999));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(999));
                 Assert.That(mobState.CurrentState, Is.EqualTo(CEMobState.Critical));
             });
 
@@ -248,7 +247,7 @@ public sealed class CEHealthSystemTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(damageable.TotalDamage, Is.EqualTo(0));
+                Assert.That(damageable.Damage.Total, Is.EqualTo(0));
                 Assert.That(mobState.CurrentState, Is.EqualTo(CEMobState.Alive));
                 Assert.That(mobStateSystem.IsAlive(ent), Is.True);
             });
@@ -286,14 +285,13 @@ public sealed class CEHealthSystemTest : GameTest
             damageableSystem.TakeDamage(ent, new CEDamageSpecifier(TestDamageType, 1));
         });
 
-        await server.WaitIdleAsync();
+        await server.WaitRunTicks(10);
 
         await server.WaitAssertion(() =>
         {
             Assert.That(entManager.EntityExists(ent), Is.False);
         });
     }
-    */
 
     #region CEDamageSpecifier Math
 

--- a/Content.Shared/_CE/Health/CEDestructibleSystem.cs
+++ b/Content.Shared/_CE/Health/CEDestructibleSystem.cs
@@ -90,7 +90,10 @@ public sealed class CEDestructibleSystem : EntitySystem
         else if (xform.MapUid != null)
             position = new EntityCoordinates(xform.MapUid.Value, _transform.GetWorldPosition(xform));
         else
+        {
+            PredictedQueueDel(uid);
             return;
+        }
 
         if (comp.DestroySound is not null && _net.IsServer)
             _audio.PlayPvs(comp.DestroySound, xform.Coordinates);

--- a/Content.Shared/_CE/Health/CEMobStateSystem.cs
+++ b/Content.Shared/_CE/Health/CEMobStateSystem.cs
@@ -137,7 +137,10 @@ public sealed partial class CEMobStateSystem : EntitySystem
             case CEMobState.Critical:
                 _standing.Down(target);
                 _status.TryAddStatusEffectDuration(target, _fightStatus, TimeSpan.FromSeconds(5));
-                _combat.SetInCombatMode(target, false);
+
+                if (TryComp<CombatModeComponent>(target, out var combatMode))
+                    _combat.SetInCombatMode(target, false, combatMode);
+
                 var dropEv = new DropHandItemsEvent();
                 RaiseLocalEvent(target, ref dropEv);
                 break;


### PR DESCRIPTION
## About the PR
I'm not sure about this, but it seems the tests have been fixed and are working as intended

The fix adds a check for the CombatMode component before changing the combat mode when entering a critical state, as well as proper handling of entity destruction in nullspace

## Media
<img width="682" height="46" alt="image" src="https://github.com/user-attachments/assets/e8bbb028-4e1a-40f6-8453-8654dc685663" />                   
 
---
no cl, no fun
