### PR TITLE
Mana multiply x5

### DIFF
--- a/Content.Client/Audio/ContentAudioSystem.cs
+++ b/Content.Client/Audio/ContentAudioSystem.cs
@@ -29,7 +29,7 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
     public const float AmbientMusicMultiplier = 3f;
     public const float LobbyMultiplier = 3f;
     public const float InterfaceMultiplier = 2f;
-    
+
     public override void Initialize()
     {
         base.Initialize();
@@ -81,7 +81,7 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
         if (!_timing.IsFirstTimePredicted)
             return;
 
-        UpdateAmbientMusic();
+        //UpdateAmbientMusic(); //CrystallEdge disabled ambient music
         UpdateLobbyMusic();
         UpdateFades(frameTime);
     }

--- a/Content.Shared/_CE/Mana/Core/Components/CEMagicEnergyContainerComponent.cs
+++ b/Content.Shared/_CE/Mana/Core/Components/CEMagicEnergyContainerComponent.cs
@@ -13,19 +13,19 @@ public sealed partial class CEMagicEnergyContainerComponent : Component
     /// Current available energy.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int Energy = 20;
+    public int Energy = 100;
 
     /// <summary>
     /// Base maximum energy before modifiers.
     /// Used as the starting value for <see cref="CECalculateMaxManaEvent"/>.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int BaseMaxEnergy = 20;
+    public int BaseMaxEnergy = 100;
 
     /// <summary>
     /// Effective maximum energy after modifiers (flat + multipliers).
     /// Set by <see cref="CESharedMagicEnergySystem.RefreshMaxMana"/>.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int MaxEnergy = 20;
+    public int MaxEnergy = 100;
 }

--- a/Resources/Prototypes/_CE/Entities/Mobs/NPCs/fire_construct.yml
+++ b/Resources/Prototypes/_CE/Entities/Mobs/NPCs/fire_construct.yml
@@ -12,8 +12,8 @@
   - type: CEDestructible
     destroyThreshold: 150
   - type: CEMagicEnergyContainer
-    energy: 100
-    baseMaxEnergy: 100
+    energy: 500
+    baseMaxEnergy: 500
   - type: CEGOAP
     goals:
     - desiredState:
@@ -110,8 +110,6 @@
   name: Fire construct explosion
   description: TODO
   components:
-  - type: CEActionManaCost
-    manaCost: 1
   - type: Action
     useDelay: 15
   - type: InstantAction
@@ -165,7 +163,7 @@
     width: 35
     range: 5
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 15
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Entities/Mobs/NPCs/flem.yml
+++ b/Resources/Prototypes/_CE/Entities/Mobs/NPCs/flem.yml
@@ -11,8 +11,8 @@
   components:
   - type: CEGOAPAlarm
   - type: CEMagicEnergyContainer
-    energy: 100
-    baseMaxEnergy: 100
+    energy: 500
+    baseMaxEnergy: 500
   - type: CEGOAP
     goals:
     # Most important - stay alive

--- a/Resources/Prototypes/_CE/Entities/Mobs/NPCs/gnome.yml
+++ b/Resources/Prototypes/_CE/Entities/Mobs/NPCs/gnome.yml
@@ -9,6 +9,9 @@
   description: TODO
   categories: [ ForkFiltered ]
   components:
+  - type: CEMagicEnergyContainer
+    energy: 50
+    baseMaxEnergy: 50
   - type: CEGOAPAlarm
     sound:
       path: /Audio/_CE/Mobs/gnome5.ogg
@@ -370,6 +373,8 @@
     icon:
       sprite: _CE/Skills/Priest/cure_wounds.rsi
       state: icon
+  - type: CEActionManaCost
+    manaCost: 10
   - type: TargetAction
     range: 1.5
     interactOnMiss: false

--- a/Resources/Prototypes/_CE/Entities/Objects/Consumables/Flowers/blue_aelyta.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Consumables/Flowers/blue_aelyta.yml
@@ -38,7 +38,7 @@
       collection: eating
     effects:
     - !type:RestoreMana
-      amount: 1
+      amount: 5
     - !type:ApplyStatusEffectStack
       effectTarget: Target
       statusEffect: CEStatusEffectPoison

--- a/Resources/Prototypes/_CE/Entities/Objects/Consumables/Potions/mana_restore.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Consumables/Potions/mana_restore.yml
@@ -27,7 +27,7 @@
         - CEMobState
       effects:
       - !type:RestoreMana
-        amount: 2
+        amount: 10
       - !type:SpawnEntity
         spawns:
         - CEEffectManaRestore
@@ -52,7 +52,7 @@
   - type: CEConsumable
     effects:
     - !type:RestoreMana
-      amount: 10
+      amount: 50
     - !type:SpawnEntity
       spawns:
       - CEEffectManaRestore
@@ -65,7 +65,7 @@
         - CEMobState
       effects:
       - !type:RestoreMana
-        amount: 5
+        amount: 25
       - !type:SpawnEntity
         spawns:
         - CEEffectManaRestore
@@ -91,7 +91,7 @@
   - type: CEConsumable
     effects:
     - !type:RestoreMana
-      amount: 5
+      amount: 25
       applyModifiers: false
     - !type:SpawnEntity
       spawns:
@@ -105,7 +105,7 @@
         - CEMobState
       effects:
       - !type:RestoreMana
-        amount: 2
+        amount: 10
         applyModifiers: false
       - !type:SpawnEntity
         spawns:
@@ -132,7 +132,7 @@
   - type: CEConsumable
     effects:
     - !type:RestoreMana
-      amount: 10
+      amount: 50
       applyModifiers: false
     - !type:SpawnEntity
       spawns:
@@ -146,7 +146,7 @@
         - CEMobState
       effects:
       - !type:RestoreMana
-        amount: 5
+        amount: 25
         applyModifiers: false
       - !type:SpawnEntity
         spawns:

--- a/Resources/Prototypes/_CE/Entities/Objects/Weapons/Magic/curse_staff.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Weapons/Magic/curse_staff.yml
@@ -76,7 +76,7 @@
           Poison: 5
   - type: CEEntityEffectSpawner
     frequency: 0.2
-    firstDelay: 0.5
+    firstDelay: 0.8
     effects:
     - !type:CETileAffectArea
       effectTarget: Used

--- a/Resources/Prototypes/_CE/Entities/Objects/Weapons/Melee/spear_soul_catcher.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Weapons/Melee/spear_soul_catcher.yml
@@ -23,7 +23,7 @@
             types:
               Cold: 5
         - !type:StealMana
-          amount: 2
+          amount: 10
         - !type:SpawnEntity
           effectTarget: Target
           spawns:
@@ -39,7 +39,7 @@
             types:
               Cold: 10
         - !type:StealMana
-          amount: 4
+          amount: 20
         - !type:SpawnEntity
           effectTarget: Target
           spawns:

--- a/Resources/Prototypes/_CE/Recipes/AlchemyTable/mana_conservation.yml
+++ b/Resources/Prototypes/_CE/Recipes/AlchemyTable/mana_conservation.yml
@@ -5,7 +5,7 @@
   craftTime: 1
   requirements:
   - !type:MagicEnergyResource
-    amount: 5
+    amount: 25
   - !type:TagResource
     tag: Vials
     count: 1
@@ -19,7 +19,7 @@
   craftTime: 1
   requirements:
   - !type:MagicEnergyResource
-    amount: 10
+    amount: 50
   - !type:TagResource
     tag: Vials
     count: 1

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/amplification.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/amplification.yml
@@ -11,7 +11,7 @@
   description: Gives you [color=#b2e3eb]10 stacks of Strength[/color], increasing melee damage.
   components:
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 15
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
@@ -11,7 +11,7 @@
   description: Your next melee attack applies [color=#b2e3eb]5 Bruise[/color] stacks, increasing the physical damage taken by targets.
   components:
   - type: CEActionManaCost
-    manaCost: 4
+    manaCost: 20
   - type: CEActionWeaponRequired
   - type: Action
     useDelay: 10

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/flame_absorption.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/flame_absorption.yml
@@ -14,7 +14,7 @@
     sprite: _CE/Skills/Knight/fire_absorption.rsi
     state: icon
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 10
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
@@ -14,7 +14,7 @@
     sprite: _CE/Skills/Knight/iron_bulwark.rsi
     state: icon
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 10
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/raise_shields.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/raise_shields.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 1.5
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 10
   - type: Action
     useDelay: 15
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/fire_wave.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/fire_wave.yml
@@ -14,7 +14,7 @@
     width: 90
     range: 3
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 15
   - type: Action
     useDelay: 3
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
@@ -14,7 +14,7 @@
     width: 1.0
     projectileMode: true
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 10
   - type: Action
     useDelay: 6
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
@@ -14,7 +14,7 @@
     width: 2.5
     projectileMode: true
   - type: CEActionManaCost
-    manaCost: 5
+    manaCost: 25
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/frost_blade.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/frost_blade.yml
@@ -11,7 +11,7 @@
   description: You create a powerful temporary weapon made of ice that deals high damage and [color=#30caf5]freezes[/color] targets.
   components:
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 17
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/frost_flow.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/frost_flow.yml
@@ -14,7 +14,7 @@
     width: 2.5
     projectileMode: true
   - type: CEActionManaCost
-    manaCost: 5
+    manaCost: 25
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/healing_frost.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/healing_frost.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 0.5
   - type: CEActionManaCost
-    manaCost: 4
+    manaCost: 20
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/mana_gift.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/mana_gift.yml
@@ -8,14 +8,14 @@
   id: CEActionManaGift
   parent: CEActionSpellBase
   name: Mana Gift
-  description: Restore [color=#3082f5]5 mana[/color] to the selected target
+  description: Restore [color=#3082f5]25 mana[/color] to the selected target
   components:
   - type: CEVisualizeRadiusTargetAction
   - type: CEVisualizeAoEZoneAction
     radius: 0.5
   - type: CEActionManaCost
     canModifyManacost: false
-    manaCost: 5
+    manaCost: 25
   - type: Action
     useDelay: 2
     icon:
@@ -49,7 +49,7 @@
       spawns:
       - CEEffectManaRestore
     - !type:RestoreMana
-      amount: 5
+      amount: 25
       applyModifiers: false
 
 - type: entity

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/mana_steal.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/mana_steal.yml
@@ -8,7 +8,7 @@
   id: CEActionManaSteal
   parent: CEActionSpellBase
   name: Mana Steal
-  description: Steal [color=#3082f5]4 mana[/color] from the selected target and transfer it to yourself.
+  description: Steal [color=#3082f5]20 mana[/color] from the selected target and transfer it to yourself.
   components:
   - type: CEVisualizeRadiusTargetAction
   - type: CEVisualizeAoEZoneAction
@@ -46,7 +46,7 @@
       spawns:
       - CEEffectManaRestore
     - !type:StealMana
-      amount: 4
+      amount: 20
 
 - type: entity
   id: CEEffectManaDrain

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/recharge.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/recharge.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 0.5
   - type: CEActionManaCost
-    manaCost: 10
+    manaCost: 50
   - type: Action
     useDelay: 2
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/triple_icicles.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/triple_icicles.yml
@@ -17,7 +17,7 @@
     projectileMode: true
     width: 0.5
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 15
   - type: Action
     useDelay: 3
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/acceleration.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/acceleration.yml
@@ -11,7 +11,7 @@
   description: Increases your movement speed for a short duration.
   components:
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 10
   - type: Action
     useDelay: 3
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/fire_creation.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/fire_creation.yml
@@ -17,7 +17,7 @@
   description: You create a temporary [color=#ff4500]fire[/color], which you can throw.
   components:
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 5
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/rat_throw.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/rat_throw.yml
@@ -15,7 +15,7 @@
     width: 1.0
     projectileMode: true
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 8
   - type: Action
     useDelay: 2
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/self_treatment.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/self_treatment.yml
@@ -21,7 +21,7 @@
   description: You restore [color=#1defa9]10 health[/color] to yourself.
   components:
   - type: CEActionManaCost
-    manaCost: 4
+    manaCost: 20
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_cold.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_cold.yml
@@ -15,7 +15,7 @@
   description: Grants [color=#b2e3eb]20 temporary Frost shields[/color] that absorb damage. Shields decay over time.
   components:
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 7
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_fire.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_fire.yml
@@ -15,7 +15,7 @@
   description: Grants [color=#b2e3eb]20 temporary fire shields[/color] that absorb damage. Shields decay over time.
   components:
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 7
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_physical.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_physical.yml
@@ -20,7 +20,7 @@
   description: Grants [color=#b2e3eb]20 temporary Physical shields[/color] that absorb damage. Shields decay over time.
   components:
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 7
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/soul_eater.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/soul_eater.yml
@@ -9,7 +9,7 @@
   id: CEActionSpellSoulEater
   parent: CEActionSpellBase
   name: Soul Eater
-  description: You restore [color=#1776eb]1 mana[/color].
+  description: You restore [color=#1776eb]5 mana[/color].
   components:
   - type: CEActionSoulCost
     cost: 1
@@ -65,7 +65,7 @@
       spawns:
       - CEEffectManaRestore
     - !type:RestoreMana
-      amount: 1
+      amount: 5
 
 - type: entity
   id: CESoulShardDummy

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/sphere_of_light.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/sphere_of_light.yml
@@ -15,7 +15,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 3 #Light radius
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 3
   - type: CEActionFreeHandsRequired
   - type: Action
     useDelay: 10

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/water_creation.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/water_creation.yml
@@ -17,7 +17,7 @@
   description: You create a temporary [color=#30caf5]water sphere[/color], which you can throw.
   components:
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 5
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Passives/open_hearted.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Passives/open_hearted.yml
@@ -13,13 +13,13 @@
 - type: entity
   id: CEStatusEffectOpenHearted
   name: Open-Hearted
-  description: When you [color=#1776eb]restore mana[/color], you restore [color=#1776eb]1[/color] more mana
+  description: When you [color=#1776eb]restore mana[/color], you restore [color=#1776eb]5[/color] more mana
   components:
   - type: StatusEffect
   - type: StatusEffectAlert
     alert: CEOpenHearted
   - type: CEBonusIncomingManaStatusEffect
-    amount: 1
+    amount: 5
 
 - type: alert
   id: CEOpenHearted

--- a/Resources/Prototypes/_CE/Skills/Neutral/Passives/wisdom.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Passives/wisdom.yml
@@ -11,8 +11,8 @@
 - type: entity
   id: CEStatusEffectWisdom
   name: Wisdom
-  description: Your maximum mana is increased by [color=#3296fa]10[/color].
+  description: Your maximum mana is increased by [color=#3296fa]50[/color].
   components:
   - type: StatusEffect
   - type: CEWisdomStatusEffect
-    flatManaBonus: 10
+    flatManaBonus: 50

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/area_healing.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/area_healing.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 1.2 # Healing radius
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 12
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/cure_wounds.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/cure_wounds.yml
@@ -17,7 +17,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 0.5
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 15
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/curse.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/curse.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 2.5
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 12
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/divine_shield.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/divine_shield.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 0.5
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 7
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/holy_ground.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/holy_ground.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 2.5
   - type: CEActionManaCost
-    manaCost: 3
+    manaCost: 18
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/purification.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/purification.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 0.5
   - type: CEActionManaCost
-    manaCost: 2
+    manaCost: 7
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/water_burst.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/water_burst.yml
@@ -14,7 +14,7 @@
   - type: CEVisualizeAoEZoneAction
     radius: 3.0
   - type: CEActionManaCost
-    manaCost: 1
+    manaCost: 8
   - type: Action
     useDelay: 8
     icon:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

**Changelog**
:cl:
- tweak: Player mana, all manacostes and mana restoring sources multiplied by 5. So, we have 100 mana instead 20 by default.
- tweak: Gnomes now have mana and use it to heal themselves. As a result, gnomes' healing is now limited.
- fix: Fixed a bug where the Cursed Staff would curse the user when used
- remove: Disabled vanilla ambient music
