### PR TITLE
Real CBT restrictions

### DIFF
--- a/Resources/ConfigPresets/_CE/Dev.toml
+++ b/Resources/ConfigPresets/_CE/Dev.toml
@@ -23,7 +23,7 @@ desc = "A multiplayer party-based roguelike. A roguelike in which dozens of team
 lobbyenabled = true
 soft_max_players = 30
 maxplayers = 40
-lobbyduration = 300
+lobbyduration = 18000
 role_timers = true
 
 #[server]

--- a/Resources/Prototypes/_CE/Entities/Objects/Consumables/Potions/mana_restore.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Consumables/Potions/mana_restore.yml
@@ -14,7 +14,7 @@
   - type: CEConsumable
     effects:
     - !type:RestoreMana
-      amount: 5
+      amount: 25
     - !type:SpawnEntity
       spawns:
       - CEEffectManaRestore
@@ -27,7 +27,7 @@
         - CEMobState
       effects:
       - !type:RestoreMana
-        amount: 10
+        amount: 12
       - !type:SpawnEntity
         spawns:
         - CEEffectManaRestore
@@ -105,7 +105,7 @@
         - CEMobState
       effects:
       - !type:RestoreMana
-        amount: 10
+        amount: 12
         applyModifiers: false
       - !type:SpawnEntity
         spawns:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

**Changelog**
:cl:
- fix: The standard wait time in the lobby has been increased from 5 minutes to 5 hours. The admins are tired of shutting down the server after every update. The admins can still hold impromptu closed beta tests in the middle of the day.
- fix: Fixed small mana potions restore 5 mana instead 25.
