### PR TITLE
Loot distribution update + stamina cost actions

### DIFF
--- a/Content.Client/_CE/Procedural/CEDungeonAtlasOverlay.cs
+++ b/Content.Client/_CE/Procedural/CEDungeonAtlasOverlay.cs
@@ -120,7 +120,7 @@ public sealed class CEDungeonAtlasOverlay : Overlay
 
     private void GetRoomTypeColors(CEDungeonRoom3DPrototype room, out Color fill, out Color border)
     {
-        if (room.RoomType != null && _proto.TryIndex(room.RoomType.Value, out CERoomTypePrototype? roomType))
+        if (room.RoomType != null && _proto.Resolve(room.RoomType.Value, out var roomType))
         {
             fill   = roomType.DebugFillColor;
             border = roomType.DebugBorderColor;

--- a/Content.Server/_CE/Procedural/PostProcess/CEBudgetSpawnPostProcess.cs
+++ b/Content.Server/_CE/Procedural/PostProcess/CEBudgetSpawnPostProcess.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Content.Shared._CE.Procedural;
 using Content.Shared.Maps;
 using Content.Shared.Whitelist;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -39,13 +40,6 @@ public sealed partial class CEBudgetSpawnPostProcess : CEDungeonPostProcessLayer
     /// </summary>
     [DataField]
     public EntityWhitelist? AnchoredWhitelist;
-
-    /// <summary>
-    /// Room types to exclude from spawning. Tiles inside rooms of these types
-    /// will not be considered as candidates.
-    /// </summary>
-    [DataField]
-    public List<ProtoId<CERoomTypePrototype>> ExcludedRoomTypes = new();
 
     /// <summary>
     /// If true, only spawn on the main z-level (as defined by the dungeon level prototype).
@@ -221,23 +215,17 @@ public sealed partial class CEBudgetSpawnPostProcess : CEDungeonPostProcessLayer
         return null;
     }
 
-    /// <summary>
-    /// Reads room data from the dungeon component on the map and builds
-    /// a list of bounding boxes for rooms whose type is in <see cref="ExcludedRoomTypes"/>.
-    /// </summary>
     private List<(Vector2i Pos, Vector2i Size)> BuildExcludedZones(IEntityManager entMan, EntityUid mapUid)
     {
         var zones = new List<(Vector2i Pos, Vector2i Size)>();
 
-        if (ExcludedRoomTypes.Count == 0)
-            return zones;
-
         if (!entMan.TryGetComponent<CEGeneratingProceduralDungeonComponent>(mapUid, out var dungeon))
             return zones;
 
+        var proto = IoCManager.Resolve<IPrototypeManager>();
         foreach (var room in dungeon.Rooms)
         {
-            if (room.RoomType != null && ExcludedRoomTypes.Contains(room.RoomType.Value))
+            if (room.RoomType != null && proto.Resolve(room.RoomType.Value, out var roomTypeProto) && !roomTypeProto.AllowLootSpawn)
                 zones.Add((room.Position, room.Size));
         }
 

--- a/Content.Server/_CE/Procedural/PostProcess/CEEntityTableBudgetSpawnPostProcess.cs
+++ b/Content.Server/_CE/Procedural/PostProcess/CEEntityTableBudgetSpawnPostProcess.cs
@@ -4,6 +4,7 @@ using Content.Shared.EntityTable;
 using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Maps;
 using Content.Shared.Whitelist;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -41,13 +42,6 @@ public sealed partial class CEEntityTableBudgetSpawnPostProcess : CEDungeonPostP
     /// </summary>
     [DataField]
     public EntityWhitelist? AnchoredWhitelist;
-
-    /// <summary>
-    /// Room types to exclude from spawning. Tiles inside rooms of these types
-    /// will not be considered as candidates.
-    /// </summary>
-    [DataField]
-    public List<ProtoId<CERoomTypePrototype>> ExcludedRoomTypes = new();
 
     /// <summary>
     /// If true, only spawn on the main z-level (as defined by the dungeon level prototype).
@@ -231,15 +225,13 @@ public sealed partial class CEEntityTableBudgetSpawnPostProcess : CEDungeonPostP
     {
         var zones = new List<(Vector2i Pos, Vector2i Size)>();
 
-        if (ExcludedRoomTypes.Count == 0)
-            return zones;
-
         if (!entMan.TryGetComponent<CEGeneratingProceduralDungeonComponent>(mapUid, out var dungeon))
             return zones;
 
+        var proto = IoCManager.Resolve<IPrototypeManager>();
         foreach (var room in dungeon.Rooms)
         {
-            if (room.RoomType != null && ExcludedRoomTypes.Contains(room.RoomType.Value))
+            if (room.RoomType != null && proto.Resolve(room.RoomType.Value, out var roomTypeProto) && !roomTypeProto.AllowLootSpawn)
                 zones.Add((room.Position, room.Size));
         }
 

--- a/Content.Server/_CE/Procedural/PostProcess/CEMobBudgetSpawnPostProcess.cs
+++ b/Content.Server/_CE/Procedural/PostProcess/CEMobBudgetSpawnPostProcess.cs
@@ -5,6 +5,7 @@ using Content.Shared._CE.GOAP;
 using Content.Shared._CE.Procedural;
 using Content.Shared.Maps;
 using Content.Shared.Whitelist;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -48,9 +49,6 @@ public sealed partial class CEMobBudgetSpawnPostProcess : CEDungeonPostProcessLa
 
     [DataField]
     public EntityWhitelist? AnchoredWhitelist;
-
-    [DataField]
-    public List<ProtoId<CERoomTypePrototype>> ExcludedRoomTypes = new();
 
     [DataField]
     public bool MainZLevelOnly = true;
@@ -292,15 +290,13 @@ public sealed partial class CEMobBudgetSpawnPostProcess : CEDungeonPostProcessLa
     private List<(Vector2i Pos, Vector2i Size)> BuildExcludedZones(IEntityManager entMan, EntityUid mapUid)
     {
         var zones = new List<(Vector2i Pos, Vector2i Size)>();
-        if (ExcludedRoomTypes.Count == 0)
-            return zones;
-
         if (!entMan.TryGetComponent<CEGeneratingProceduralDungeonComponent>(mapUid, out var dungeon))
             return zones;
 
+        var proto = IoCManager.Resolve<IPrototypeManager>();
         foreach (var room in dungeon.Rooms)
         {
-            if (room.RoomType != null && ExcludedRoomTypes.Contains(room.RoomType.Value))
+            if (room.RoomType != null && proto.Resolve(room.RoomType.Value, out var roomTypeProto) && !roomTypeProto.AllowMobsSpawn)
                 zones.Add((room.Position, room.Size));
         }
         return zones;

--- a/Content.Server/_CE/Procedural/PostProcess/CETableBudgetSpawnPostProcess.cs
+++ b/Content.Server/_CE/Procedural/PostProcess/CETableBudgetSpawnPostProcess.cs
@@ -36,7 +36,6 @@ public sealed partial class CETableBudgetSpawnPostProcess : CEDungeonPostProcess
             Entries = table.Entries,
             TileWhitelist = table.TileWhitelist,
             AnchoredWhitelist = table.AnchoredWhitelist,
-            ExcludedRoomTypes = table.ExcludedRoomTypes,
             MainZLevelOnly = table.MainZLevelOnly,
         };
 

--- a/Content.Server/_CE/Procedural/Prototypes/CEDungeonSpawnTablePrototype.cs
+++ b/Content.Server/_CE/Procedural/Prototypes/CEDungeonSpawnTablePrototype.cs
@@ -1,5 +1,4 @@
 using Content.Server._CE.Procedural.PostProcess;
-using Content.Shared._CE.Procedural;
 using Content.Shared.Maps;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
@@ -35,12 +34,6 @@ public sealed partial class CEDungeonSpawnTablePrototype : IPrototype
     /// </summary>
     [DataField]
     public EntityWhitelist? AnchoredWhitelist;
-
-    /// <summary>
-    /// Room types to exclude from spawning.
-    /// </summary>
-    [DataField]
-    public List<ProtoId<CERoomTypePrototype>> ExcludedRoomTypes = new();
 
     /// <summary>
     /// If true, only spawn on the main z-level. When false, spawns across all z-levels.

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.Attempt.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.Attempt.cs
@@ -3,6 +3,7 @@ using Content.Shared._CE.Animation.Item.Components;
 using Content.Shared._CE.Health.Components;
 using Content.Shared._CE.Mana.Core.Components;
 using Content.Shared._CE.Soul.Components;
+using Content.Shared._CE.Stamina;
 using Content.Shared._CE.StatusEffects.ActionBlocker;
 using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
@@ -22,6 +23,7 @@ public abstract partial class CESharedActionSystem
         SubscribeLocalEvent<CEActionFreeHandsRequiredComponent, ActionAttemptEvent>(OnSomaticActionAttempt);
         SubscribeLocalEvent<CEActionManaCostComponent, ActionAttemptEvent>(OnManacostActionAttempt);
         SubscribeLocalEvent<CEActionSoulCostComponent, ActionAttemptEvent>(OnSoulcostActionAttempt);
+        SubscribeLocalEvent<CEActionStaminaCostComponent, ActionAttemptEvent>(OnStaminaCostActionAttempt);
         SubscribeLocalEvent<CEActionWeaponRequiredComponent, ActionAttemptEvent>(OnWeaponRequiredActionAttempt);
 
         SubscribeLocalEvent<CEActionSSDBlockComponent, ActionValidateEvent>(OnActionSSDAttempt);
@@ -195,5 +197,14 @@ public abstract partial class CESharedActionSystem
             Popup.PopupClient(Loc.GetString("ce-magic-spell-ssd"), args.User, args.User);
             args.Invalid = true;
         }
+    }
+
+    private void OnStaminaCostActionAttempt(Entity<CEActionStaminaCostComponent> ent, ref ActionAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!_stamina.CanAfford(args.User))
+            args.Cancelled = true;
     }
 }

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.Examine.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.Examine.cs
@@ -12,10 +12,16 @@ public abstract partial class CESharedActionSystem
         SubscribeLocalEvent<ActionComponent, ExaminedEvent>(OnActionExamined);
         SubscribeLocalEvent<CEActionManaCostComponent, ExaminedEvent>(OnManacostExamined);
         SubscribeLocalEvent<CEActionSoulCostComponent, ExaminedEvent>(OnSoulCostExamined);
+        SubscribeLocalEvent<CEActionStaminaCostComponent, ExaminedEvent>(OnStaminaCostExamined);
 
         SubscribeLocalEvent<CEActionFreeHandsRequiredComponent, ExaminedEvent>(OnSomaticExamined);
         SubscribeLocalEvent<CEActionTargetMobStatusRequiredComponent, ExaminedEvent>(OnMobStateExamined);
         SubscribeLocalEvent<CEActionWeaponRequiredComponent, ExaminedEvent>(OnWeaponRequiredExamined);
+    }
+
+    private void OnStaminaCostExamined(Entity<CEActionStaminaCostComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup($"{Loc.GetString("ce-magic-staminacost")}: [color=#90ee90]{ent.Comp.Cost}[/color]", priority: 9);
     }
 
     private void OnSoulCostExamined(Entity<CEActionSoulCostComponent> ent, ref ExaminedEvent args)

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.Resource.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.Resource.cs
@@ -1,6 +1,7 @@
 using Content.Shared._CE.Actions.Components;
 using Content.Shared._CE.Mana.Core.Components;
 using Content.Shared._CE.Soul.Components;
+using Content.Shared._CE.Stamina;
 using Content.Shared.Actions.Events;
 
 namespace Content.Shared._CE.Actions;
@@ -11,6 +12,7 @@ public abstract partial class CESharedActionSystem
     {
         SubscribeLocalEvent<CEActionManaCostComponent, ActionPerformedEvent>(OnManaCostActionPerformed);
         SubscribeLocalEvent<CEActionSoulCostComponent, ActionPerformedEvent>(OnSoulCostActionPerformed);
+        SubscribeLocalEvent<CEActionStaminaCostComponent, ActionPerformedEvent>(OnStaminaCostActionPerformed);
     }
 
     private void OnManaCostActionPerformed(Entity<CEActionManaCostComponent> ent, ref ActionPerformedEvent args)
@@ -53,5 +55,10 @@ public abstract partial class CESharedActionSystem
             return;
 
         _soul.TryRemoveSouls((args.Performer, playerSoul), ent.Comp.Cost);
+    }
+
+    private void OnStaminaCostActionPerformed(Entity<CEActionStaminaCostComponent> ent, ref ActionPerformedEvent args)
+    {
+        _stamina.TryTakeDamage(args.Performer, ent.Comp.Cost);
     }
 }

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.cs
@@ -45,7 +45,10 @@ public abstract partial class CESharedActionSystem : EntitySystem
         if (args.Handled)
             return;
 
-        _animation.TryPlayAnimationToAngle(ent, args.Animation, null, args.Action.Comp.Container, args.Speed, args.CancelAnimation);
+        if (_animation.IsPlayingAnimation(ent))
+            return;
+
+        _animation.TryPlayAnimationToAngle(ent, args.Animation, null, args.Action.Comp.Container, args.Speed);
         args.Handled = true;
     }
 
@@ -54,7 +57,10 @@ public abstract partial class CESharedActionSystem : EntitySystem
         if (args.Handled)
             return;
 
-        _animation.TryPlayAnimationToCoordinates(ent, args.Animation, args.Target, args.Action.Comp.Container, args.Speed, args.CancelAnimation);
+        if (_animation.IsPlayingAnimation(ent))
+            return;
+
+        _animation.TryPlayAnimationToCoordinates(ent, args.Animation, args.Target, args.Action.Comp.Container, args.Speed);
         args.Handled = true;
     }
 
@@ -63,12 +69,16 @@ public abstract partial class CESharedActionSystem : EntitySystem
         if (args.Handled)
             return;
 
+        if (_animation.IsPlayingAnimation(ent))
+            return;
+
         var playerPos = _transform.GetMapCoordinates(ent).Position;
         var targetPos = _transform.ToMapCoordinates(args.Target).Position;
         var direction = targetPos - playerPos;
         var angle = Angle.FromWorldVec(direction);
 
-        _animation.TryPlayAnimationToAngle(ent, args.Animation, angle, args.Action.Comp.Container, args.Speed, args.CancelAnimation);
+        _animation.TryPlayAnimationToAngle(ent, args.Animation, angle, args.Action.Comp.Container, args.Speed);
+        args.Handled = true;
     }
 
     private void OnEntityTargetAction(Entity<TransformComponent> ent, ref CEEntityTargetActionAnimationEvent args)
@@ -76,7 +86,10 @@ public abstract partial class CESharedActionSystem : EntitySystem
         if (args.Handled)
             return;
 
-        _animation.TryPlayAnimationToEntity(ent, args.Animation, args.Target, args.Action.Comp.Container, args.Speed, args.CancelAnimation);
+        if (_animation.IsPlayingAnimation(ent))
+            return;
+
+        _animation.TryPlayAnimationToEntity(ent, args.Animation, args.Target, args.Action.Comp.Container, args.Speed);
         args.Handled = true;
     }
 }
@@ -89,9 +102,6 @@ public sealed partial class CEInstantActionAnimationEvent : InstantActionEvent
 
     [DataField]
     public float Speed = 1f;
-
-    [DataField]
-    public bool CancelAnimation = true;
 }
 
 public sealed partial class CEWorldTargetActionAnimationEvent : WorldTargetActionEvent
@@ -101,9 +111,6 @@ public sealed partial class CEWorldTargetActionAnimationEvent : WorldTargetActio
 
     [DataField]
     public float Speed = 1f;
-
-    [DataField]
-    public bool CancelAnimation = true;
 }
 
 public sealed partial class CEAngleActionAnimationEvent : WorldTargetActionEvent
@@ -113,9 +120,6 @@ public sealed partial class CEAngleActionAnimationEvent : WorldTargetActionEvent
 
     [DataField]
     public float Speed = 1f;
-
-    [DataField]
-    public bool CancelAnimation = true;
 }
 
 
@@ -126,9 +130,6 @@ public sealed partial class CEEntityTargetActionAnimationEvent : EntityTargetAct
 
     [DataField]
     public float Speed = 1f;
-
-    [DataField]
-    public bool CancelAnimation;
 }
 
 /// <summary>

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._CE.Animation.Core;
 using Content.Shared._CE.Animation.Core.Prototypes;
 using Content.Shared._CE.Mana.Core;
 using Content.Shared._CE.Soul;
+using Content.Shared._CE.Stamina;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -19,6 +20,7 @@ public abstract partial class CESharedActionSystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _hand = default!;
     [Dependency] private readonly CESharedMagicEnergySystem _magicEnergy = default!;
     [Dependency] private readonly CESharedSoulSystem _soul = default!;
+    [Dependency] private readonly CEStaminaSystem _stamina = default!;
 
     private EntityQuery<ActionComponent> _actionQuery;
 

--- a/Content.Shared/_CE/Actions/Components/CEActionStaminaCostComponent.cs
+++ b/Content.Shared/_CE/Actions/Components/CEActionStaminaCostComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared._CE.Actions.Components;
+
+/// <summary>
+/// Restricts the use of this action by spending stamina.
+/// The action is blocked when the performer is exhausted or has zero stamina.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CEActionStaminaCostComponent : Component
+{
+    /// <summary>
+    /// Amount of stamina consumed when the action is performed.
+    /// </summary>
+    [DataField(required: true)]
+    public float Cost = 1f;
+}

--- a/Content.Shared/_CE/Procedural/CERoomTypePrototype.cs
+++ b/Content.Shared/_CE/Procedural/CERoomTypePrototype.cs
@@ -70,4 +70,18 @@ public sealed partial class CERoomTypePrototype : IPrototype
     /// </summary>
     [DataField]
     public bool SecretRoom;
+
+    /// <summary>
+    /// When <c>true</c> (default), mob-spawn post-process layers are allowed to place mobs in this room.
+    /// Set to <c>false</c> on room types that should never contain hostile mobs (e.g. entrance or secret rooms).
+    /// </summary>
+    [DataField]
+    public bool AllowMobsSpawn = true;
+
+    /// <summary>
+    /// When <c>true</c> (default), loot-spawn post-process layers are allowed to place items in this room.
+    /// Set to <c>false</c> on room types that should never receive randomly spawned loot.
+    /// </summary>
+    [DataField]
+    public bool AllowLootSpawn = true;
 }

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1.yml
@@ -67,9 +67,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 20
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobRat
       cost: 1

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1.yml
@@ -46,7 +46,7 @@
       attachToTypes:
       - MossyTempleGeneralRoom
       count:
-        min: 0
+        min: 1
         max: 1
     - !type:AppendRoom
       roomType: MossyTempleSecretRoom

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1_pvp.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1_pvp.yml
@@ -46,7 +46,7 @@
       attachToTypes:
       - MossyTempleGeneralRoom
       count:
-        min: 0
+        min: 1
         max: 1
     - !type:AppendRoom
       roomType: MossyTempleSecretRoom

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1_pvp.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/1_pvp.yml
@@ -67,9 +67,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 10
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobRat
       cost: 1

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2.yml
@@ -67,9 +67,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 30
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobRat
       cost: 1

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2.yml
@@ -46,7 +46,7 @@
       attachToTypes:
       - MossyTempleGeneralRoom
       count:
-        min: 0
+        min: 1
         max: 1
     - !type:AppendRoom
       roomType: MossyTempleSecretRoom

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2_pvp.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2_pvp.yml
@@ -53,7 +53,7 @@
       attachToTypes:
       - MossyTempleGeneralRoom
       count:
-        min: 0
+        min: 1
         max: 1
     - !type:MarkDeadEnds
       ofType: MossyTempleGeneralRoom

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2_pvp.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/2_pvp.yml
@@ -67,9 +67,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 15
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobRat
       cost: 1

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/3.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/3.yml
@@ -60,9 +60,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 40
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobSlimeWater
       cost: 2

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/3_pvp.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/3_pvp.yml
@@ -53,9 +53,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 20
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobSlimeWater
       cost: 2

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/4.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/4.yml
@@ -74,9 +74,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 100
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobSlimeFire
       cost: 3

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/4_pvp.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/4_pvp.yml
@@ -74,9 +74,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 40
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobSlimeFire
       cost: 3

--- a/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/6.yml
+++ b/Resources/Prototypes/_CE/Procedural/Levels/MossyTemple/6.yml
@@ -53,9 +53,6 @@
   postProcess:
   - !type:CEMobBudgetSpawnPostProcess
     budget: 80
-    excludedRoomTypes:
-    - MossyTempleEntranceRoom
-    - MossyTempleSecretRoom
     entries:
     - proto: CEMobSlimeFire
       cost: 3

--- a/Resources/Prototypes/_CE/Procedural/room_types.yml
+++ b/Resources/Prototypes/_CE/Procedural/room_types.yml
@@ -15,6 +15,7 @@
   id: MossyTempleEntranceRoom
   supportsWideConnection: true
   secretRoom: true #Intended
+  allowMobsSpawn: false
   color: "#4b944b"
   minimapIcon:
     sprite: /Textures/_CE/Interface/minimap_icons.rsi
@@ -33,6 +34,8 @@
   doorPrototype: CEGoldenLockedDoor
   supportsWideConnection: false
   showIconFromNeighbour: true
+  allowMobsSpawn: false
+  allowLootSpawn: false
   color: "#FFD700"
   minimapIcon:
     sprite: /Textures/_CE/Interface/minimap_icons.rsi
@@ -56,6 +59,8 @@
   doorPrototype: CEGoldenLockedDoor
   supportsWideConnection: false
   showIconFromNeighbour: true
+  allowMobsSpawn: false
+  allowLootSpawn: false
   color: "#b587dd"
   minimapIcon:
     sprite: /Textures/_CE/Interface/minimap_icons.rsi
@@ -66,6 +71,8 @@
   doorPrototype: CEWallWoodenDark
   supportsWideConnection: false
   secretRoom: true
+  allowMobsSpawn: false
+  allowLootSpawn: false
   color: "#3e3e3e"
   minimapIcon:
     sprite: /Textures/_CE/Interface/minimap_icons.rsi

--- a/Resources/Prototypes/_CE/Procedural/room_types.yml
+++ b/Resources/Prototypes/_CE/Procedural/room_types.yml
@@ -45,9 +45,7 @@
 
 - type: dungeonRoomType
   id: MossyTempleAlchemyRoom
-  doorPrototype: CEGoldenLockedDoor
-  supportsWideConnection: false
-  showIconFromNeighbour: true
+  supportsWideConnection: true
   color: "#00f2ff"
   minimapIcon:
     sprite: /Textures/_CE/Interface/minimap_icons.rsi

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/cruelty.yml
@@ -12,6 +12,8 @@
   components:
   - type: CEActionManaCost
     manaCost: 20
+  - type: CEActionStaminaCost
+    cost: 2
   - type: CEActionWeaponRequired
   - type: Action
     useDelay: 10

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/iron_bulwark.yml
@@ -15,6 +15,8 @@
     state: icon
   - type: CEActionManaCost
     manaCost: 10
+  - type: CEActionStaminaCost
+    cost: 3
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/raise_shields.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/raise_shields.yml
@@ -15,6 +15,8 @@
     radius: 1.5
   - type: CEActionManaCost
     manaCost: 10
+  - type: CEActionStaminaCost
+    cost: 3
   - type: Action
     useDelay: 15
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/fire_wave.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/fire_wave.yml
@@ -15,12 +15,15 @@
     range: 3
   - type: CEActionManaCost
     manaCost: 15
+  - type: CEActionStaminaCost
+    cost: 4
   - type: Action
-    useDelay: 3
+    useDelay: 1
     icon:
       sprite: _CE/Skills/Mage/fire_wave.rsi
       state: icon
   - type: TargetAction
+    repeat: true
     checkCanAccess: false
     range: 20
   - type: WorldTargetAction
@@ -38,7 +41,7 @@
       projectileSpeed: 3
       projectileMaxSpeed: 4
       prototype: CEProjectileFireWave
-      projectileCount: 10
+      projectileCount: 7
       spread: 0.2
 
 - type: entity
@@ -73,8 +76,8 @@
       attackType: Ranged
       damage:
         types:
-          Fire: 1
+          Fire: 2
     - !type:ApplyStatusEffectStack
       statusEffect: CEStatusEffectFire
       amount: 1
-      max: 5
+      max: 8

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
@@ -15,8 +15,10 @@
     projectileMode: true
   - type: CEActionManaCost
     manaCost: 10
+  - type: CEActionStaminaCost
+    cost: 6
   - type: Action
-    useDelay: 6
+    useDelay: 1
     icon:
       sprite: _CE/Skills/Mage/firebolt.rsi
       state: icon

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
@@ -14,7 +14,9 @@
     width: 2.5
     projectileMode: true
   - type: CEActionManaCost
-    manaCost: 25
+    manaCost: 20
+  - type: CEActionStaminaCost
+    cost: 4
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/frost_flow.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/frost_flow.yml
@@ -14,7 +14,9 @@
     width: 2.5
     projectileMode: true
   - type: CEActionManaCost
-    manaCost: 25
+    manaCost: 20
+  - type: CEActionStaminaCost
+    cost: 4
   - type: Action
     useDelay: 8
     icon:

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/triple_icicles.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/triple_icicles.yml
@@ -18,6 +18,8 @@
     width: 0.5
   - type: CEActionManaCost
     manaCost: 15
+  - type: CEActionStaminaCost
+    cost: 4
   - type: Action
     useDelay: 3
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/fire_creation.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/fire_creation.yml
@@ -18,6 +18,8 @@
   components:
   - type: CEActionManaCost
     manaCost: 5
+  - type: CEActionStaminaCost
+    cost: 2
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/rat_throw.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/rat_throw.yml
@@ -16,12 +16,15 @@
     projectileMode: true
   - type: CEActionManaCost
     manaCost: 8
+  - type: CEActionStaminaCost
+    cost: 6
   - type: Action
-    useDelay: 2
+    useDelay: 0.5
     icon:
       sprite: _CE/Objects/Weapons/Projectile/rat_flying.rsi
       state: aaa
   - type: TargetAction
+    repeat: true
     checkCanAccess: false
     range: 20
   - type: WorldTargetAction

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_cold.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_cold.yml
@@ -16,6 +16,8 @@
   components:
   - type: CEActionManaCost
     manaCost: 7
+  - type: CEActionStaminaCost
+    cost: 2
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_fire.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_fire.yml
@@ -16,6 +16,8 @@
   components:
   - type: CEActionManaCost
     manaCost: 7
+  - type: CEActionStaminaCost
+    cost: 2
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_physical.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/small_barrier_physical.yml
@@ -21,6 +21,8 @@
   components:
   - type: CEActionManaCost
     manaCost: 7
+  - type: CEActionStaminaCost
+    cost: 2
   - type: Action
     useDelay: 10
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/soul_eater.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/soul_eater.yml
@@ -13,6 +13,8 @@
   components:
   - type: CEActionSoulCost
     cost: 1
+  - type: CEActionStaminaCost
+    cost: 3
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/water_creation.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/water_creation.yml
@@ -18,6 +18,8 @@
   components:
   - type: CEActionManaCost
     manaCost: 5
+  - type: CEActionStaminaCost
+    cost: 2
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/area_healing.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/area_healing.yml
@@ -15,6 +15,8 @@
     radius: 1.2 # Healing radius
   - type: CEActionManaCost
     manaCost: 12
+  - type: CEActionStaminaCost
+    cost: 3
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/cure_wounds.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/cure_wounds.yml
@@ -18,6 +18,8 @@
     radius: 0.5
   - type: CEActionManaCost
     manaCost: 15
+  - type: CEActionStaminaCost
+    cost: 3
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/curse.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/curse.yml
@@ -15,6 +15,8 @@
     radius: 2.5
   - type: CEActionManaCost
     manaCost: 12
+  - type: CEActionStaminaCost
+    cost: 4
   - type: Action
     useDelay: 5
     icon:

--- a/Resources/Prototypes/_CE/Skills/Priest/Actives/water_burst.yml
+++ b/Resources/Prototypes/_CE/Skills/Priest/Actives/water_burst.yml
@@ -15,6 +15,8 @@
     radius: 3.0
   - type: CEActionManaCost
     manaCost: 8
+  - type: CEActionStaminaCost
+    cost: 3
   - type: Action
     useDelay: 8
     icon:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

## Media
<!-- Attach media if the PR makes in-game changes. -->
<img width="126" height="112" alt="image" src="https://github.com/user-attachments/assets/d2cf4383-3ea4-4753-ae40-ea5f738386b8" />

**Changelog**
:cl:
- add: Most combat spells now consume stamina to cast. Some spells now have very short cooldowns but high stamina costs, allowing you to cast them repeatedly as long as you have enough stamina.
- tweak: Libraries now spawn 100% of the time on the first floor, and alchemy rooms on the second floor
- tweak: The alchemy rooms no longer require keys to enter
- tweak: Keys, mobs, and other random loot will no longer spawn in locked rooms (secrets, treasures, libraries)
- fix: Fixed a bug where casting multiple spells in quick succession could cancel the effects of some of them, resulting in wasted resources 
