### PR TITLE
Fix QuickEquip accessories

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -50,32 +50,49 @@ public abstract class ClothingSystem : EntitySystem
         Entity<ClothingComponent> toEquipEnt,
         Entity<InventoryComponent, HandsComponent> userEnt)
     {
+        // First pass: try to find an empty slot that can accept the item.
         foreach (var slotDef in userEnt.Comp1.Slots)
         {
             if (!_invSystem.CanEquip(userEnt, toEquipEnt, slotDef.Name, out _, slotDef, userEnt, toEquipEnt))
                 continue;
 
-            if (_invSystem.TryGetSlotEntity(userEnt, slotDef.Name, out var slotEntity, userEnt))
+            if (_invSystem.TryGetSlotEntity(userEnt, slotDef.Name, out _, userEnt))
+                continue; // slot occupied — skip in first pass
+
+            // Found a valid empty slot. Equip (or start do-after) and stop regardless of return value.
+            _invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoafter: true, triggerHandContact: true);
+            return;
+        }
+
+        // Second pass: no empty slot found — swap with the first occupied slot whose item allows quick-equip.
+        foreach (var slotDef in userEnt.Comp1.Slots)
+        {
+            if (!_invSystem.CanEquip(userEnt, toEquipEnt, slotDef.Name, out _, slotDef, userEnt, toEquipEnt))
+                continue;
+
+            if (!_invSystem.TryGetSlotEntity(userEnt, slotDef.Name, out var slotEntity, userEnt))
+                continue; // empty slot — already tried in first pass
+
+            // Item in slot has to be quick equipable as well
+            if (TryComp<ClothingComponent>(slotEntity, out var existingItem) && !existingItem.QuickEquip)
+                continue;
+
+            // If the existing item has an unequip delay, TryUnequip will start a do-after (return false).
+            // Treat it as committed to this slot anyway — stop iterating to avoid triggering
+            // unequip do-afters on all other occupied slots.
+            var hasUnequipDelay = existingItem != null && existingItem.UnequipDelay > TimeSpan.Zero;
+
+            if (!_invSystem.TryUnequip(userEnt, slotDef.Name, true, inventory: userEnt, checkDoafter: true))
             {
-                // Item in slot has to be quick equipable as well
-                if (TryComp(slotEntity, out ClothingComponent? item) && !item.QuickEquip)
-                    continue;
-
-                if (!_invSystem.TryUnequip(userEnt, slotDef.Name, true, inventory: userEnt, checkDoafter: true))
-                    continue;
-
-                if (!_invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoafter: true, triggerHandContact: true))
-                    continue;
-
-                _handsSystem.PickupOrDrop(userEnt, slotEntity.Value, handsComp: userEnt);
-            }
-            else
-            {
-                if (!_invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoafter: true, triggerHandContact: true))
-                    continue;
+                if (hasUnequipDelay)
+                    return; // do-after started, committed to this slot
+                continue;   // genuine failure (CanUnequip blocked) — try next slot
             }
 
-            break;
+            // Instant unequip succeeded — equip new item into the now-empty slot.
+            _invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoafter: true, triggerHandContact: true);
+            _handsSystem.PickupOrDrop(userEnt, slotEntity.Value, handsComp: userEnt);
+            return;
         }
     }
 

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/_base.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/_base.yml
@@ -12,3 +12,5 @@
     - eyes
   - type: Sprite
     state: icon
+  - type: Item
+    size: Normal

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/amulet_fire_star.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/amulet_fire_star.yml
@@ -4,8 +4,6 @@
   name: "Laozel's Scorching Edge"
   description: A mystical amulet shaped like a fire. Increases all outgoing [color=#ff4500]fire damage[/color] by 3.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/fire_star.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/amulet_ice_star.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/amulet_ice_star.yml
@@ -4,8 +4,6 @@
   name: Mierza star
   description: A mystical amulet shaped like a frozen star. Increases all outgoing [color=#05eeff]cold damage[/color] by 3.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/ice_star.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/amulet_vitality.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/amulet_vitality.yml
@@ -4,8 +4,6 @@
   name: vitality amulet
   description: An amulet that enhances the body's ability to heal, increasing all incoming healing by 5.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/vitality_amulet.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/bezoar.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/bezoar.yml
@@ -4,8 +4,6 @@
   name: bezoar
   description: Protects the wearer from poisoning.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/bezoar.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/crown_of_thorns.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/crown_of_thorns.yml
@@ -4,8 +4,6 @@
   name: crown of thorns
   description: When you take damage in melee combat, you deal 6 physical damage to the attacker.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/crown_of_thorns.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/energy_geode.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/energy_geode.yml
@@ -4,8 +4,6 @@
   name: energy geode
   description: A cracked geode containing energy crystals. It increases the owner's [color=#3296fa]maximum mana pool by 20[/color] and can function as a energy storage.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/energy_geode.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/fighter_gloves.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/fighter_gloves.yml
@@ -4,8 +4,6 @@
   name: fighter Gloves
   description: Heavyweight fighting gloves. Increases all outgoing melee [color=#05eeff]physical damage[/color] by 3.
   components:
-  - type: Item
-    size: Normal
   - type: Sprite
     sprite: _CE/Clothing/Accessory/fighter_gloves.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/flaming_stone.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/flaming_stone.yml
@@ -4,8 +4,6 @@
   name: flaming stone
   description: Your melee attacks set targets on [color=#ff4500]fire[/color]
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/flaming_stone.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/ninja_bandana.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/ninja_bandana.yml
@@ -4,8 +4,6 @@
   name: ninja bandana
   description: Increases max [color=#32cd32]stamina[/color] by 3
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/ninja_bandana.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/ring_fire.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/ring_fire.yml
@@ -4,8 +4,6 @@
   name: fire ring
   description: A protective ring that shields the carrier from the heat of the fire.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/ring_fire.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Clothing/Accessory/ring_frost.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/Accessory/ring_frost.yml
@@ -4,8 +4,6 @@
   name: frost ring
   description: A protective ring that shields the carrier from the cold.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: _CE/Clothing/Accessory/ring_frost.rsi
   - type: CEEquipStatusEffect

--- a/Resources/Prototypes/_CE/Entities/Objects/Weapons/Throwing/dagger.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Weapons/Throwing/dagger.yml
@@ -48,7 +48,7 @@
           attackType: Melee
           damage:
             types:
-              Physical: 12
+              Physical: 9
       OnHeavyHit:
       - !type:WeaponArcAttack
         range: 0.6
@@ -58,7 +58,7 @@
           attackType: Melee
           damage:
             types:
-              Physical: 15
+              Physical: 13
     animations:
       Primary:
       - anim: DaggerAttackLight1


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

**Changelog**
:cl:
- fix: Fixed a bug where accessories were placed in a pocket instead of being equipped when used
- tweak: Nerfed daggers: melee damage decreased from 12 to 9