### PR TITLE
Stone Moment

### DIFF
--- a/Content.Client/_CE/EntityEffect/Effects/UserAnimation.cs
+++ b/Content.Client/_CE/EntityEffect/Effects/UserAnimation.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared._CE.EntityEffect;
 using Content.Shared._CE.EntityEffect.Effects;
+using Content.Shared._CE.ZLevels.Core.Components;
 using Robust.Client.GameObjects;
 using Robust.Shared.Timing;
 
@@ -67,8 +68,13 @@ public sealed partial class CEUserAnimationEffectSystem : CEEntityEffectSystem<U
 
         if (effect.OffsetAnimation.Count > 0)
         {
-            // Preserve the original value only on the first call (not on re-interruptions).
-            comp.OriginalOffset ??= sprite.Offset;
+            if (comp.OriginalOffset == null)
+            {
+                // Use Z-free base: sprite.Offset at tick time includes jump height from post-anim; restoring it would double the Z.
+                comp.OriginalOffset = TryComp<CEZPhysicsComponent>(entity, out var zPhys)
+                    ? zPhys.SpriteOffsetDefault
+                    : sprite.Offset;
+            }
             _animPlayer.Stop(entity, OffsetKey);
             _animPlayer.Play(entity, CEAnimationTrackBuilders.BuildOffsetAnimation(effect.OffsetAnimation, speedMult), OffsetKey);
         }

--- a/Content.Client/_CE/ZLevels/Core/CEClientZLevelsSystem.cs
+++ b/Content.Client/_CE/ZLevels/Core/CEClientZLevelsSystem.cs
@@ -8,8 +8,10 @@ using Content.Client._CE.ZLevels.Core.Overlays;
 using Content.Shared._CE.ZLevels.Core.Components;
 using Content.Shared._CE.ZLevels.Core.EntitySystems;
 using Content.Shared.Camera;
+using Content.Shared.StatusEffectNew.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
+using Robust.Shared.Map.Components;
 
 namespace Content.Client._CE.ZLevels.Core;
 
@@ -101,6 +103,9 @@ internal sealed class CEClientZLevelsPostAnimSystem : EntitySystem
 {
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
+    [Dependency] private readonly EntityQuery<MapGridComponent> _mapGridQuery = default!;
+    [Dependency] private readonly EntityQuery<CEZPhysicsComponent> _zPhysQuery = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -115,6 +120,23 @@ internal sealed class CEClientZLevelsPostAnimSystem : EntitySystem
         while (query.MoveNext(out var uid, out var zPhys, out var sprite))
         {
             var zOffset = new Vector2(0, zPhys.LocalPosition * CESharedZLevelsSystem.ZLevelOffset);
+            _sprite.SetOffset((uid, sprite), sprite.Offset + zOffset);
+        }
+
+        // Parent-sync pass: entities marked with CEZLevelOffsetParentSyncComponent inherit
+        // their visual Z offset from the parent entity's CEZPhysicsComponent.
+        var syncQuery = EntityQueryEnumerator<StatusEffectComponent, SpriteComponent, TransformComponent>();
+        while (syncQuery.MoveNext(out var uid, out _, out var sprite, out var xform))
+        {
+            var parent = xform.ParentUid;
+
+            if (_mapGridQuery.HasComp(parent))
+                continue;
+
+            if (!_zPhysQuery.TryComp(parent, out var parentZPhys))
+                continue;
+
+            var zOffset = new Vector2(0, parentZPhys.LocalPosition * CESharedZLevelsSystem.ZLevelOffset);
             _sprite.SetOffset((uid, sprite), sprite.Offset + zOffset);
         }
     }

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -77,7 +77,7 @@ public sealed partial class StatusEffectsSystem
         SubscribeLocalEvent<StatusEffectContainerComponent, CESoulReceivedEvent>(RefRelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, CEAttemptApplyTileEffectEvent>(RefRelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, ActionAttemptEvent>(RefRelayStatusEffectEvent);
-        SubscribeLocalEvent<StatusEffectContainerComponent, CEZLevelFallMapEvent>(RefRelayStatusEffectEvent);
+        SubscribeLocalEvent<StatusEffectContainerComponent, CEZLevelHitEvent>(RefRelayStatusEffectEvent);
 
         //CrystallEdge zone end
 

--- a/Content.Shared/_CE/StatusEffects/CEEffectOnLandingStatusEffect.cs
+++ b/Content.Shared/_CE/StatusEffects/CEEffectOnLandingStatusEffect.cs
@@ -20,10 +20,10 @@ public sealed class CEEffectOnLandingStatusEffectSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CEEffectOnLandingStatusEffectComponent, StatusEffectRelayedEvent<CEZLevelFallMapEvent>>(OnFall);
+        SubscribeLocalEvent<CEEffectOnLandingStatusEffectComponent, StatusEffectRelayedEvent<CEZLevelHitEvent>>(OnFall);
     }
 
-    private void OnFall(Entity<CEEffectOnLandingStatusEffectComponent> ent, ref StatusEffectRelayedEvent<CEZLevelFallMapEvent> args)
+    private void OnFall(Entity<CEEffectOnLandingStatusEffectComponent> ent, ref StatusEffectRelayedEvent<CEZLevelHitEvent> args)
     {
         if (!_effectQuery.TryComp(ent, out var effectComp) || effectComp.AppliedTo is null)
             return;

--- a/Content.Shared/_CE/ZLevels/Core/EntitySystems/CESharedZLevelsSystem.Movement.cs
+++ b/Content.Shared/_CE/ZLevels/Core/EntitySystems/CESharedZLevelsSystem.Movement.cs
@@ -237,6 +237,7 @@ public abstract partial class CESharedZLevelsSystem
 
         ent.Comp.LocalPosition = newPosition;
         DirtyField(ent, ent.Comp, nameof(CEZPhysicsComponent.LocalPosition));
+        WakeBody(ent);
     }
 
     [PublicAPI]
@@ -258,6 +259,7 @@ public abstract partial class CESharedZLevelsSystem
 
         ent.Comp.GravityMultiplier = newGravityMultiplier;
         DirtyField(ent, ent.Comp, nameof(CEZPhysicsComponent.GravityMultiplier));
+        WakeBody(ent);
     }
 
     /// <summary>
@@ -271,6 +273,7 @@ public abstract partial class CESharedZLevelsSystem
 
         ent.Comp.Velocity = newVelocity;
         DirtyField(ent, ent.Comp, nameof(CEZPhysicsComponent.Velocity));
+        WakeBody(ent);
     }
 
     /// <summary>
@@ -284,6 +287,7 @@ public abstract partial class CESharedZLevelsSystem
 
         ent.Comp.Velocity += newVelocity;
         DirtyField(ent, ent.Comp, nameof(CEZPhysicsComponent.Velocity));
+        WakeBody(ent);
     }
 
     [PublicAPI]

--- a/Resources/Prototypes/_CE/Entities/StatusEffects/frozen.yml
+++ b/Resources/Prototypes/_CE/Entities/StatusEffects/frozen.yml
@@ -58,6 +58,26 @@
   - type: CEActionsProvideStatusEffect
     actions:
     - CEActionFrozenBreak
+  - type: CEEffectOnLandingStatusEffect
+    effects:
+    - !type:ShockWaveVFX
+      effectTarget: User
+      width: 0.1
+    - !type:CETileAffectArea
+      tileEffect: CETileEffectFreeze
+      radius: 1
+      maxStacks: 5
+    - !type:AreaEffect
+      range: 2
+      affectCaster: false
+      effects:
+      - !type:Damage
+        effectTarget: Target
+        attackType: Melee
+        damage:
+          types:
+            Cold: 10
+            Physical: 10
 
 - type: alert
   id: CEFrozen

--- a/Resources/Prototypes/_CE/Entities/StatusEffects/petrification.yml
+++ b/Resources/Prototypes/_CE/Entities/StatusEffects/petrification.yml
@@ -1,0 +1,162 @@
+- type: entity
+  id: CEStatusEffectPetrification
+  name: Petrification
+  components:
+  - type: CENegativeStatusEffect
+  - type: StatusEffect
+    whitelist:
+      components:
+      - CEDamageable
+  - type: StatusEffectAlert
+    alert: CEPetrification
+  - type: RejuvenateRemovedStatusEffect
+  - type: CETempShieldStatusEffect
+    absorbPerStack: 4
+    all: true
+  - type: CEActionBlockerStatusEffect
+    blockActions: true
+    blockUse: true
+    blockAttack: true
+    blockMove: true
+    blockThrow: true
+    blockDrop: true
+    blockPickup: true
+    blockPull: true
+    blockStand: true
+    blockEquip: true
+    blockUnequip: true
+  - type: Sprite
+    drawdepth: Effects
+    sprite: _CE/Structures/Nature/ice_rock.rsi
+    noRot: true
+    color: "#5e5438" #TODO
+    layers:
+    - state: big
+      map: [ "status" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.CEStatusEffectStackVisuals.Level:
+        status:
+          Low: { state: smol }
+          Medium: { state: med }
+          High: { state: big }
+  - type: Appearance
+  - type: CEStatusEffectStack
+    stackDelta: -1
+    baseDuration: 2
+    mediumAppearance: 5
+    highAppearance: 10
+  - type: CEActionsProvideStatusEffect
+    actions:
+    - CEActionPetrificationBreak
+  - type: CEEffectOnLandingStatusEffect
+    effects:
+    - !type:ShockWaveVFX
+      effectTarget: User
+      width: 0.1
+    - !type:SpawnEntity
+      effectTarget: User
+      spawns:
+      - CEDustTileEffect
+    - !type:AreaEffect
+      range: 2
+      affectCaster: false
+      effects:
+      - !type:Damage
+        effectTarget: Target
+        attackType: Melee
+        damage:
+          types:
+            Physical: 20
+      - !type:ThrowFromUser
+        effectTarget: Target
+        distance: 1
+        throwPower: 10
+      - !type:SpawnEntity
+        effectTarget: Target
+        spawns:
+        - CEDustTileEffect
+
+- type: alert
+  id: CEPetrification
+  alertViewEntity: CEPetrificationAlertSpriteView
+  name: ce-alert-petrification-name
+  description: ce-alert-petrification-desc
+  icons:
+  - sprite: _CE/Structures/Nature/ice_rock.rsi
+    state: med
+    color: "#5e5438" #TODO
+
+- type: entity
+  id: CEPetrificationAlertSpriteView
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GenericCounterAlert
+    centerGlyph: false
+    hideLeadingZeroes: true
+  - type: Sprite
+    sprite: /Textures/Interface/Alerts/essence_counter.rsi
+    layers:
+    - sprite: _CE/Structures/Nature/ice_rock.rsi
+      state: med
+      color: "#5e5438" #TODO
+    - map: [ "1" ]
+      offset: 0.65, 0
+    - map: [ "10" ]
+      offset: 0.45, 0
+    - map: [ "100" ]
+      offset: 0.25, 0
+
+- type: entity
+  id: CEActionPetrificationBreak
+  parent: CEActionSpellBase
+  name: Break free
+  description: You break free from the stone trap.
+  components:
+  - type: CEActionStaminaCost
+    cost: 8
+  - type: Action
+    useDelay: 4
+    startDelay: true
+    checkCanInteract: false
+    icon:
+      sprite: _CE/Structures/Nature/ice_rock.rsi
+      state: break
+  - type: InstantAction
+    event: !type:CEInstantActionAnimationEvent
+      animation: PetrificationBreak
+
+- type: entityEffectAnimation
+  id: PetrificationBreak
+  movementSpeed: 0
+  duration: 0.5
+  events:
+    0:
+    - !type:UserAnimation
+      offsetAnimation:
+      - time: 0.0
+        offset: 0.1, 0
+      - time: 0.1
+        offset: -0.1, 0
+      - time: 0.2
+        offset: 0.1, 0
+      - time: 0.3
+        offset: -0.1, 0
+      - time: 0.4
+        offset: 0.1, 0
+    0.4:
+    - !type:ShockWaveVFX
+      effectTarget: User
+      width: 0.05
+    - !type:PlaySound
+      sound:
+        path: /Audio/Effects/break_stone.ogg
+        params:
+          variation: 0.02
+    - !type:RemoveStatusEffectStack
+      effectTarget: User
+      statusEffect: CEStatusEffectPetrification
+      amount: 15
+    - !type:SpawnEntity
+      spawns:
+      - CEDustTileEffect

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/stone_moment.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/stone_moment.yml
@@ -1,0 +1,41 @@
+- type: skill
+  parent: BaseKnightSkill
+  id: StoneMoment
+  effect: !type:AddAction
+    action: CEActionSpellStoneMoment
+
+- type: entity
+  id: CEActionSpellStoneMoment
+  parent: CEActionSpellBase
+  name: A Moment in Stone
+  description: You instantly turn yourself into a stone that blocks incoming damage.
+  components:
+  - type: CEActionManaCost
+    manaCost: 10
+  - type: CEActionStaminaCost
+    cost: 3
+  - type: Action
+    useDelay: 15
+    icon:
+      sprite: _CE/Skills/Knight/stone_skin.rsi #TODO
+      state: icon
+  - type: InstantAction
+    event: !type:CEInstantActionAnimationEvent
+      animation: StoneMoment
+
+- type: entityEffectAnimation
+  id: StoneMoment
+  movementSpeed: 0.5
+  duration: 1
+  events:
+    0:
+    - !type:PlaySound
+      sound:
+        path: /Audio/Effects/clang.ogg
+        params:
+          pitch: 0.7
+    0.6:
+    - !type:ApplyStatusEffectStack
+      effectTarget: User
+      statusEffect: CEStatusEffectPetrification
+      amount: 15

--- a/Resources/Prototypes/_CE/Skills/Knight/Actives/stone_moment.yml
+++ b/Resources/Prototypes/_CE/Skills/Knight/Actives/stone_moment.yml
@@ -34,7 +34,7 @@
         path: /Audio/Effects/clang.ogg
         params:
           pitch: 0.7
-    0.6:
+    0.1:
     - !type:ApplyStatusEffectStack
       effectTarget: User
       statusEffect: CEStatusEffectPetrification

--- a/Resources/Prototypes/_CE/Skills/Neutral/Actives/jump.yml
+++ b/Resources/Prototypes/_CE/Skills/Neutral/Actives/jump.yml
@@ -24,7 +24,7 @@
 - type: entityEffectAnimation
   id: AnimationJump
   movementSpeed: 1
-  duration: 1
+  duration: 0.4
   events:
     0:
     #- !type:PlaySound


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

**Changelog**
:cl:
- add: A new active ability for the Knight, “Stone's Blink,” has been added. It instantly applies a new petrification status effect to the user, granting sturdy shields and immobilizing them.
- add: Creatures affected by freeze and petrification effects now cause a shockwave when they fall from a height. Freeze and repulsion effects correspondingly.
- fix: Fixed bugs related to jumping and fall effects that were not working properly on certain z-levels
