### PR TITLE
Fix debug assertion error happening on crystal UI (issue #179)

### DIFF
--- a/Content.Client/_CE/Procedural/Overview/CEDungeonOverviewControl.xaml.cs
+++ b/Content.Client/_CE/Procedural/Overview/CEDungeonOverviewControl.xaml.cs
@@ -153,7 +153,8 @@ public sealed partial class CEDungeonOverviewControl : BoxContainer
         LevelName.SetMessage(FormattedMessage.FromMarkupPermissive(
             Loc.GetString("ce-dungeon-overview-no-selection")));
         LevelDesc.SetMessage(FormattedMessage.FromMarkupPermissive(string.Empty));
-        DetailsContainer.RemoveAllChildren();
+        if (!DetailsContainer.Disposed)
+            DetailsContainer.RemoveAllChildren();
     }
 
     private void ShowLevelDetails(string levelId)


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Tackles #179 
Added a `Disposed` condition check to a UI container that was trying to remove its children after being disposed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Was causing a crash on debug mode upon closing the crystal's UI.