### PR TITLE
Fix Fire charge cast direction rotation on rotated cameras

### DIFF
--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
@@ -58,7 +58,7 @@
 
 - type: entity
   id: CEEffectFireboltCharge
-  parent: CEBaseMagicImpactAlt
+  parent: CEBaseMagicImpactDirectional
   categories: [ ForkFiltered ]
   suffix: VFX
   name: firebolt charge

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firebolt.yml
@@ -58,7 +58,7 @@
 
 - type: entity
   id: CEEffectFireboltCharge
-  parent: CEBaseMagicImpact
+  parent: CEBaseMagicImpactAlt
   categories: [ ForkFiltered ]
   suffix: VFX
   name: firebolt charge

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
@@ -80,7 +80,7 @@
 
 - type: entity
   id: CEEffectFireballCharge
-  parent: CEBaseMagicImpactAlt
+  parent: CEBaseMagicImpactDirectional
   categories: [ ForkFiltered ]
   suffix: VFX
   name: fireball charge

--- a/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
+++ b/Resources/Prototypes/_CE/Skills/Mage/Actives/firewall.yml
@@ -80,7 +80,7 @@
 
 - type: entity
   id: CEEffectFireballCharge
-  parent: CEBaseMagicImpact
+  parent: CEBaseMagicImpactAlt
   categories: [ ForkFiltered ]
   suffix: VFX
   name: fireball charge

--- a/Resources/Prototypes/_CE/Skills/spell_base.yml
+++ b/Resources/Prototypes/_CE/Skills/spell_base.yml
@@ -42,4 +42,3 @@
   - type: Sprite
     drawdepth: Effects
     sprite: _CE/Effects/cast_impact48.rsi
-    noRot: true

--- a/Resources/Prototypes/_CE/Skills/spell_base.yml
+++ b/Resources/Prototypes/_CE/Skills/spell_base.yml
@@ -42,3 +42,14 @@
   - type: Sprite
     drawdepth: Effects
     sprite: _CE/Effects/cast_impact48.rsi
+    noRot: true
+
+- type: entity
+  parent: CEBaseMagicImpact
+  id: CEBaseMagicImpactAlt
+  name: magic impact (alt)
+  description: manifestation of magical energy in the physical plane (which can rotate!)
+  abstract: true
+  components:
+  - type: Sprite
+    noRot: false

--- a/Resources/Prototypes/_CE/Skills/spell_base.yml
+++ b/Resources/Prototypes/_CE/Skills/spell_base.yml
@@ -46,8 +46,8 @@
 
 - type: entity
   parent: CEBaseMagicImpact
-  id: CEBaseMagicImpactAlt
-  name: magic impact (alt)
+  id: CEBaseMagicImpactDirectional
+  name: magic impact (directional)
   description: manifestation of magical energy in the physical plane (which can rotate!)
   abstract: true
   components:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
removes out a `noRot: true` on the mutual parent of both affected skills

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
noRot was causing the initial fire charge from both the firebolt and firewall skills to apply to weird rotations in case the camera was rotated in any way (see #173)
