### PR TITLE
Add blacklist and whitelist to throwfrom effect

### DIFF
--- a/Content.Shared/_CE/EntityEffect/Effects/ThrowFrom.cs
+++ b/Content.Shared/_CE/EntityEffect/Effects/ThrowFrom.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.Projectiles;
 using Content.Shared.Throwing;
+using Content.Shared.Whitelist;
 
 namespace Content.Shared._CE.EntityEffect.Effects;
 
@@ -17,6 +18,12 @@ public sealed partial class ThrowFrom : CEEntityEffectBase<ThrowFrom>
 
     [DataField]
     public float Distance = 2.5f;
+
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    [DataField]
+    public EntityWhitelist? Blacklist;
 }
 
 public sealed partial class CEThrowFromEffectSystem : CEEntityEffectSystem<ThrowFrom>
@@ -24,10 +31,14 @@ public sealed partial class CEThrowFromEffectSystem : CEEntityEffectSystem<Throw
     [Dependency] private ThrowingSystem _throwing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedProjectileSystem _projectile = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
     protected override void Effect(ref CEEntityEffectEvent<ThrowFrom> args)
     {
         if (ResolveEffectEntity(args.Args, args.Effect.EffectTarget) is not { } targetEntity)
+            return;
+
+        if (!_whitelist.CheckBoth(targetEntity, args.Effect.Blacklist, args.Effect.Whitelist))
             return;
 
         var originEntity = ResolveEffectEntity(args.Args, args.Effect.Origin) ?? args.Args.Source;

--- a/Resources/Prototypes/_CE/Entities/Objects/Weapons/Magic/Uncommon/water_staff.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Weapons/Magic/Uncommon/water_staff.yml
@@ -71,6 +71,9 @@
       fallOffFactor: 0.5
       maxStacks: 10
     - !type:ThrowFrom
+      blacklist:
+        components:
+        - Ghost
       throwPower: 7
       distance: 2
     - !type:Damage
@@ -83,6 +86,9 @@
       range: 2
       effects:
       - !type:ThrowFrom
+        blacklist:
+          components:
+          - Ghost
         origin: Used
         throwPower: 7
         distance: 0.25


### PR DESCRIPTION
## About the PR
🐛 
## Why / Balance
fixes  #146
## Media

**Changelog**
:cl: Cringe_Cursed
- fix: Fixed an issue where water staff projectile throw effect affected ghosts.
